### PR TITLE
Fix path in CLI output

### DIFF
--- a/includes/Checker/Abstract_Check_Runner.php
+++ b/includes/Checker/Abstract_Check_Runner.php
@@ -541,6 +541,8 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 	 * @since 1.0.0
 	 *
 	 * @return string The plugin basename to check.
+	 *
+	 * @throws Exception Thrown if an plugin basename could not be set.
 	 */
 	final public function get_plugin_basename() {
 		if ( null === $this->plugin_basename ) {
@@ -550,10 +552,16 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 				$this->plugin_basename = Plugin_Request_Utility::download_plugin( $plugin );
 
 				$this->delete_plugin_folder = true;
-			} elseif ( Plugin_Request_Utility::is_directory_valid_plugin( $plugin ) ) {
-				$this->plugin_basename = $plugin;
 			} else {
-				$this->plugin_basename = Plugin_Request_Utility::get_plugin_basename_from_input( $plugin );
+				try {
+					$this->plugin_basename = Plugin_Request_Utility::get_plugin_basename_from_input( $plugin );
+				} catch ( Exception $exception ) {
+					if ( Plugin_Request_Utility::is_directory_valid_plugin( $plugin ) ) {
+						$this->plugin_basename = $plugin;
+					} else {
+						throw $exception;
+					}
+				}
 			}
 		}
 

--- a/includes/Checker/Abstract_Check_Runner.php
+++ b/includes/Checker/Abstract_Check_Runner.php
@@ -645,6 +645,8 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 	 * @since 1.0.0
 	 *
 	 * @return string The plugin basename to check.
+	 *
+	 * @throws Exception Thrown if an plugin basename could not be set.
 	 */
 	final public function get_plugin_basename() {
 		if ( null === $this->plugin_basename ) {
@@ -654,10 +656,16 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 				$this->plugin_basename = Plugin_Request_Utility::download_plugin( $plugin );
 
 				$this->delete_plugin_folder = true;
-			} elseif ( Plugin_Request_Utility::is_directory_valid_plugin( $plugin ) ) {
-				$this->plugin_basename = $plugin;
 			} else {
-				$this->plugin_basename = Plugin_Request_Utility::get_plugin_basename_from_input( $plugin );
+				try {
+					$this->plugin_basename = Plugin_Request_Utility::get_plugin_basename_from_input( $plugin );
+				} catch ( Exception $exception ) {
+					if ( Plugin_Request_Utility::is_directory_valid_plugin( $plugin ) ) {
+						$this->plugin_basename = $plugin;
+					} else {
+						throw $exception;
+					}
+				}
 			}
 		}
 

--- a/includes/Plugin_Context.php
+++ b/includes/Plugin_Context.php
@@ -103,9 +103,9 @@ class Plugin_Context {
 	 */
 	public function path( $relative_path = '/' ) {
 		if ( is_dir( $this->main_file ) ) {
-			return realpath( trailingslashit( $this->main_file ) . ltrim( $relative_path, '/' ) );
+			return realpath( trailingslashit( $this->main_file ) . ltrim( $relative_path, '/' ) ) . '/';
 		} else {
-			return realpath( plugin_dir_path( $this->main_file ) . ltrim( $relative_path, '/' ) );
+			return realpath( plugin_dir_path( $this->main_file ) . ltrim( $relative_path, '/' ) ) . '/';
 		}
 	}
 

--- a/includes/Plugin_Context.php
+++ b/includes/Plugin_Context.php
@@ -68,7 +68,7 @@ class Plugin_Context {
 			}
 		}
 
-		$this->main_file = realpath( $this->main_file );
+		$this->main_file = $this->main_file;
 	}
 
 	/**
@@ -103,9 +103,9 @@ class Plugin_Context {
 	 */
 	public function path( $relative_path = '/' ) {
 		if ( is_dir( $this->main_file ) ) {
-			return trailingslashit( $this->main_file ) . ltrim( $relative_path, '/' );
+			return realpath( trailingslashit( $this->main_file ) . ltrim( $relative_path, '/' ) );
 		} else {
-			return plugin_dir_path( $this->main_file ) . ltrim( $relative_path, '/' );
+			return realpath( plugin_dir_path( $this->main_file ) . ltrim( $relative_path, '/' ) );
 		}
 	}
 

--- a/includes/Plugin_Context.php
+++ b/includes/Plugin_Context.php
@@ -67,6 +67,8 @@ class Plugin_Context {
 				}
 			}
 		}
+
+		$this->main_file = realpath( $this->main_file );
 	}
 
 	/**

--- a/includes/Plugin_Context.php
+++ b/includes/Plugin_Context.php
@@ -101,8 +101,6 @@ class Plugin_Context {
 		} else {
 			$this->mode = 'new';
 		}
-
-		$this->main_file = realpath( $this->main_file );
 	}
 
 	/**
@@ -159,9 +157,9 @@ class Plugin_Context {
 	 */
 	public function path( $relative_path = '/' ) {
 		if ( is_dir( $this->main_file ) ) {
-			return trailingslashit( $this->main_file ) . ltrim( $relative_path, '/' );
+			return realpath( trailingslashit( $this->main_file ) . ltrim( $relative_path, '/' ) );
 		} else {
-			return plugin_dir_path( $this->main_file ) . ltrim( $relative_path, '/' );
+			return realpath( plugin_dir_path( $this->main_file ) . ltrim( $relative_path, '/' ) );
 		}
 	}
 

--- a/includes/Plugin_Context.php
+++ b/includes/Plugin_Context.php
@@ -157,9 +157,9 @@ class Plugin_Context {
 	 */
 	public function path( $relative_path = '/' ) {
 		if ( is_dir( $this->main_file ) ) {
-			return realpath( trailingslashit( $this->main_file ) . ltrim( $relative_path, '/' ) );
+			return realpath( trailingslashit( $this->main_file ) . ltrim( $relative_path, '/' ) ) . '/';
 		} else {
-			return realpath( plugin_dir_path( $this->main_file ) . ltrim( $relative_path, '/' ) );
+			return realpath( plugin_dir_path( $this->main_file ) . ltrim( $relative_path, '/' ) ) . '/';
 		}
 	}
 

--- a/includes/Plugin_Context.php
+++ b/includes/Plugin_Context.php
@@ -101,6 +101,8 @@ class Plugin_Context {
 		} else {
 			$this->mode = 'new';
 		}
+
+		$this->main_file = realpath( $this->main_file );
 	}
 
 	/**

--- a/includes/Plugin_Context.php
+++ b/includes/Plugin_Context.php
@@ -157,10 +157,17 @@ class Plugin_Context {
 	 */
 	public function path( $relative_path = '/' ) {
 		if ( is_dir( $this->main_file ) ) {
-			return realpath( trailingslashit( $this->main_file ) . ltrim( $relative_path, '/' ) ) . '/';
+			$base = trailingslashit( $this->main_file );
 		} else {
-			return realpath( plugin_dir_path( $this->main_file ) . ltrim( $relative_path, '/' ) ) . '/';
+			$base = plugin_dir_path( $this->main_file );
 		}
+
+		$real_base = realpath( $base );
+		if ( false !== $real_base ) {
+			$base = trailingslashit( $real_base );
+		}
+
+		return $base . ltrim( $relative_path, '/' );
 	}
 
 	/**

--- a/includes/Traits/Amend_Check_Result.php
+++ b/includes/Traits/Amend_Check_Result.php
@@ -34,14 +34,13 @@ trait Amend_Check_Result {
 	 * @param int          $severity Severity level. Default is 5.
 	 */
 	protected function add_result_message_for_file( Check_Result $result, $error, $message, $code, $file, $line = 0, $column = 0, string $docs = '', $severity = 5 ) {
-		$filename = explode( $result->plugin()->path(), $file );
 
 		$result->add_message(
 			(bool) $error,
 			$message,
 			array(
 				'code'     => $code,
-				'file'     => ( 1 === count( $filename ) ) ? reset( $filename ) : $filename[1],
+				'file'     => str_replace( $result->plugin()->path(), '', $file ),
 				'line'     => $line,
 				'column'   => $column,
 				'link'     => $this->get_file_editor_url( $result, $file, $line ),

--- a/includes/Traits/Amend_Check_Result.php
+++ b/includes/Traits/Amend_Check_Result.php
@@ -34,13 +34,14 @@ trait Amend_Check_Result {
 	 * @param int          $severity Severity level. Default is 5.
 	 */
 	protected function add_result_message_for_file( Check_Result $result, $error, $message, $code, $file, $line = 0, $column = 0, string $docs = '', $severity = 5 ) {
+		$filename = explode( $result->plugin()->path(), $file );
 
 		$result->add_message(
 			(bool) $error,
 			$message,
 			array(
 				'code'     => $code,
-				'file'     => str_replace( $result->plugin()->path(), '', $file ),
+				'file'     => ( 1 === count( $filename ) ) ? reset( $filename ) : $filename[1],
 				'line'     => $line,
 				'column'   => $column,
 				'link'     => $this->get_file_editor_url( $result, $file, $line ),

--- a/includes/Traits/Amend_Check_Result.php
+++ b/includes/Traits/Amend_Check_Result.php
@@ -34,13 +34,12 @@ trait Amend_Check_Result {
 	 * @param int          $severity Severity level. Default is 5.
 	 */
 	protected function add_result_message_for_file( Check_Result $result, $error, $message, $code, $file, $line = 0, $column = 0, string $docs = '', $severity = 5 ) {
-
 		$result->add_message(
 			(bool) $error,
 			$message,
 			array(
 				'code'     => $code,
-				'file'     => str_replace( $result->plugin()->path(), '', $file ),
+				'file'     => str_replace( trailingslashit( $result->plugin()->path() ), '', $file ),
 				'line'     => $line,
 				'column'   => $column,
 				'link'     => $this->get_file_editor_url( $result, $file, $line ),

--- a/includes/Traits/Amend_Check_Result.php
+++ b/includes/Traits/Amend_Check_Result.php
@@ -34,12 +34,13 @@ trait Amend_Check_Result {
 	 * @param int          $severity Severity level. Default is 5.
 	 */
 	protected function add_result_message_for_file( Check_Result $result, $error, $message, $code, $file, $line = 0, $column = 0, string $docs = '', $severity = 5 ) {
+
 		$result->add_message(
 			(bool) $error,
 			$message,
 			array(
 				'code'     => $code,
-				'file'     => str_replace( trailingslashit( $result->plugin()->path() ), '', $file ),
+				'file'     => str_replace( $result->plugin()->path(), '', $file ),
 				'line'     => $line,
 				'column'   => $column,
 				'link'     => $this->get_file_editor_url( $result, $file, $line ),

--- a/tests/behat/features/plugin-check-remote.feature
+++ b/tests/behat/features/plugin-check-remote.feature
@@ -36,6 +36,10 @@ Feature: Test that the WP-CLI plugin check command works with remote ZIP url.
     When I run the WP-CLI command `plugin check https://github.com/WordPress/plugin-check/raw/trunk/tests/behat/testdata/foo-bar-wp.zip --fields=code,type --format=csv`
     Then STDOUT should contain:
       """
+      FILE: foo-bar-wp.php
+      """
+    And STDOUT should contain:
+      """
       WordPress.WP.AlternativeFunctions.rand_mt_rand,ERROR
       """
     And STDOUT should contain:

--- a/tests/behat/features/plugin-check-severity.feature
+++ b/tests/behat/features/plugin-check-severity.feature
@@ -65,6 +65,10 @@ Feature: Test that the severity level in plugin check works.
     When I run the WP-CLI command `plugin check foo-bar-wp --format=csv --fields=code,type,severity`
     Then STDOUT should contain:
       """
+      FILE: foo-bar-wp.php
+      """
+    And STDOUT should contain:
+      """
       allow_unfiltered_uploads_detected,ERROR,7
       """
     And STDOUT should contain:

--- a/tests/phpunit/testdata/plugins/test-plugin/test-plugin.php
+++ b/tests/phpunit/testdata/plugins/test-plugin/test-plugin.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Plugin Name: Test Plugin
+ * Plugin URI: https://github.com/WordPress/plugin-check
+ * Description: Some plugin description.
+ * Requires at least: 6.0
+ * Requires PHP: 5.6
+ * Version: 1.0.0
+ * Author: WordPress Performance Team
+ * Author URI: https://make.wordpress.org/performance/
+ * License: GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ * Text Domain: test-plugin
+ *
+ * @package test-plugin
+ */

--- a/tests/phpunit/tests/Checker/Check_Context_Tests.php
+++ b/tests/phpunit/tests/Checker/Check_Context_Tests.php
@@ -34,7 +34,7 @@ class Check_Context_Tests extends WP_UnitTestCase {
 	}
 
 	public function test_path_with_parameter() {
-		$this->assertSame( WP_PLUGIN_DIR . '/' . $this->plugin_name . '/another/folder', $this->check_context->path( '/another/folder' ) );
+		$this->assertSame( WP_PLUGIN_DIR . '/' . $this->plugin_name . '/test-content/themes', $this->check_context->path( '/test-content/themes' ) );
 	}
 
 	public function test_url() {
@@ -42,6 +42,6 @@ class Check_Context_Tests extends WP_UnitTestCase {
 	}
 
 	public function test_url_with_parameter() {
-		$this->assertSame( WP_PLUGIN_URL . '/' . $this->plugin_name . '/folder/file.css', $this->check_context->url( '/folder/file.css' ) );
+		$this->assertSame( WP_PLUGIN_URL . '/' . $this->plugin_name . '/assets/js/plugin-check-admin.js', $this->check_context->url( '/assets/js/plugin-check-admin.js' ) );
 	}
 }

--- a/tests/phpunit/tests/Checker/Check_Context_Tests.php
+++ b/tests/phpunit/tests/Checker/Check_Context_Tests.php
@@ -37,6 +37,29 @@ class Check_Context_Tests extends WP_UnitTestCase {
 		$this->assertSame( WP_PLUGIN_DIR . '/' . $this->plugin_name . '/test-content/themes', $this->check_context->path( '/test-content/themes' ) );
 	}
 
+	public function test_path_with_nonexistent_relative_path() {
+		$this->assertSame( WP_PLUGIN_DIR . '/' . $this->plugin_name . '/does-not-exist/file.php', $this->check_context->path( '/does-not-exist/file.php' ) );
+	}
+
+	public function test_path_resolves_symlinked_plugin_directory() {
+		$target  = WP_PLUGIN_DIR . '/' . $this->plugin_name;
+		$symlink = WP_PLUGIN_DIR . '/check-context-symlink-test';
+
+		if ( file_exists( $symlink ) || ! symlink( $target, $symlink ) ) {
+			$this->markTestSkipped( 'Could not create symlink fixture.' );
+		}
+
+		try {
+			$context = new Check_Context( $symlink . '/' . basename( WP_PLUGIN_CHECK_MAIN_FILE ) );
+
+			// The path must resolve to the real (non-symlinked) plugin directory,
+			// matching how PHPCS reports resolved (realpath'd) file paths.
+			$this->assertSame( realpath( $target ) . '/', $context->path() );
+		} finally {
+			unlink( $symlink );
+		}
+	}
+
 	public function test_url() {
 		$this->assertSame( WP_PLUGIN_URL . '/' . $this->plugin_name . '/', $this->check_context->url() );
 	}

--- a/tests/phpunit/tests/Checker/Check_Result_Tests.php
+++ b/tests/phpunit/tests/Checker/Check_Result_Tests.php
@@ -19,7 +19,7 @@ class Check_Result_Tests extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		$check_context = new Check_Context( 'test-plugin/test-plugin.php' );
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin/test-plugin.php' );
 
 		$this->check_result = new Check_Result( $check_context );
 	}
@@ -28,7 +28,7 @@ class Check_Result_Tests extends WP_UnitTestCase {
 		$this->assertInstanceOf( Check_Context::class, $this->check_result->plugin() );
 
 		// Check the Check_Context has the correct basename.
-		$this->assertSame( 'test-plugin/test-plugin.php', $this->check_result->plugin()->basename() );
+		$this->assertStringEndsWith( 'test-plugin/test-plugin.php', $this->check_result->plugin()->basename() );
 	}
 
 	public function test_add_message_with_warning() {
@@ -37,7 +37,7 @@ class Check_Result_Tests extends WP_UnitTestCase {
 			'Warning message',
 			array(
 				'code'   => 'test_warning',
-				'file'   => 'test-plugin/test-plugin.php',
+				'file'   => UNIT_TESTS_PLUGIN_DIR . 'test-plugin/test-plugin.php',
 				'line'   => 12,
 				'column' => 40,
 			)
@@ -73,7 +73,7 @@ class Check_Result_Tests extends WP_UnitTestCase {
 			'Error message',
 			array(
 				'code'   => 'test_error',
-				'file'   => 'test-plugin/test-plugin.php',
+				'file'   => UNIT_TESTS_PLUGIN_DIR . 'test-plugin/test-plugin.php',
 				'line'   => 22,
 				'column' => 30,
 			)
@@ -113,7 +113,7 @@ class Check_Result_Tests extends WP_UnitTestCase {
 			'Error message',
 			array(
 				'code'   => 'test_error',
-				'file'   => 'test-plugin/test-plugin.php',
+				'file'   => UNIT_TESTS_PLUGIN_DIR . 'test-plugin/test-plugin.php',
 				'line'   => 22,
 				'column' => 30,
 			)
@@ -146,7 +146,7 @@ class Check_Result_Tests extends WP_UnitTestCase {
 			'Warning message',
 			array(
 				'code'   => 'test_warning',
-				'file'   => 'test-plugin/test-plugin.php',
+				'file'   => UNIT_TESTS_PLUGIN_DIR . 'test-plugin/test-plugin.php',
 				'line'   => 22,
 				'column' => 30,
 			)

--- a/tests/phpunit/tests/Plugin_Context_Tests.php
+++ b/tests/phpunit/tests/Plugin_Context_Tests.php
@@ -34,7 +34,7 @@ class Plugin_Context_Tests extends WP_UnitTestCase {
 	}
 
 	public function test_path_with_parameter() {
-		$this->assertSame( WP_PLUGIN_DIR . '/' . $this->plugin_name . '/another/folder', $this->plugin_context->path( '/another/folder' ) );
+		$this->assertSame( WP_PLUGIN_DIR . '/' . $this->plugin_name . '/test-content/themes', $this->plugin_context->path( '/test-content/themes' ) );
 	}
 
 	public function test_url() {
@@ -42,7 +42,7 @@ class Plugin_Context_Tests extends WP_UnitTestCase {
 	}
 
 	public function test_url_with_parameter() {
-		$this->assertSame( WP_PLUGIN_URL . '/' . $this->plugin_name . '/folder/file.css', $this->plugin_context->url( '/folder/file.css' ) );
+		$this->assertSame( WP_PLUGIN_URL . '/' . $this->plugin_name . '/assets/js/plugin-check-admin.js', $this->plugin_context->url( '/assets/js/plugin-check-admin.js' ) );
 	}
 
 	public function test_location() {

--- a/tests/phpunit/tests/Plugin_Context_Tests.php
+++ b/tests/phpunit/tests/Plugin_Context_Tests.php
@@ -37,6 +37,29 @@ class Plugin_Context_Tests extends WP_UnitTestCase {
 		$this->assertSame( WP_PLUGIN_DIR . '/' . $this->plugin_name . '/test-content/themes', $this->plugin_context->path( '/test-content/themes' ) );
 	}
 
+	public function test_path_with_nonexistent_relative_path() {
+		$this->assertSame( WP_PLUGIN_DIR . '/' . $this->plugin_name . '/does-not-exist/file.php', $this->plugin_context->path( '/does-not-exist/file.php' ) );
+	}
+
+	public function test_path_resolves_symlinked_plugin_directory() {
+		$target  = WP_PLUGIN_DIR . '/' . $this->plugin_name;
+		$symlink = WP_PLUGIN_DIR . '/plugin-context-symlink-test';
+
+		if ( file_exists( $symlink ) || ! symlink( $target, $symlink ) ) {
+			$this->markTestSkipped( 'Could not create symlink fixture.' );
+		}
+
+		try {
+			$context = new Plugin_Context( $symlink . '/' . basename( WP_PLUGIN_CHECK_MAIN_FILE ) );
+
+			// The path must resolve to the real (non-symlinked) plugin directory,
+			// matching how PHPCS reports resolved (realpath'd) file paths.
+			$this->assertSame( realpath( $target ) . '/', $context->path() );
+		} finally {
+			unlink( $symlink );
+		}
+	}
+
 	public function test_url() {
 		$this->assertSame( WP_PLUGIN_URL . '/' . $this->plugin_name . '/', $this->plugin_context->url() );
 	}


### PR DESCRIPTION
In PHPCS runner file name is like this:

```
/private/var/tmp/plugin-check/1725720105/foo-bar-wp/foo-bar-wp.php
```

Plugin path is:

```
/var/tmp/plugin-check/1725720105/foo-bar-wp/
```

So, with `str_replace( $result->plugin()->path(), '', $file ),`, filename becomes `/privatefoo-bar-wp.php`

That is why, Behat test is failing locally. Strangely not in GH Action.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Ftools.php%3Fpage%3Dplugin-check%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fplugin-check%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-615-d0029c282afe5a17ac5d752cd05a8c21d5bad377.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->