### PR TITLE
Fix: AI Check model preference not being applied

### DIFF
--- a/includes/Traits/AI_Check_Names.php
+++ b/includes/Traits/AI_Check_Names.php
@@ -210,25 +210,22 @@ trait AI_Check_Names {
 			return $builder;
 		}
 
-		$method = null;
-		if ( method_exists( $builder, 'using_model_preference' ) ) {
-			$method = 'using_model_preference';
-		} elseif ( method_exists( $builder, 'usingModelPreference' ) ) {
-			$method = 'usingModelPreference';
-		}
-
-		if ( ! $method ) {
-			return $builder;
-		}
-
 		$preference = $this->normalize_model_preference( $model_preference );
-		$result     = call_user_func( array( $builder, $method ), $preference );
 
-		if ( is_wp_error( $result ) ) {
-			return $result;
+		try {
+			$result = $builder->using_model_preference( $preference );
+			return $result ? $result : $builder;
+		} catch ( \Exception $e ) {
+			// If method doesn't exist or fails, return WP_Error.
+			return new WP_Error(
+				'model_preference_error',
+				sprintf(
+					/* translators: %s: Exception message */
+					__( 'Failed to apply model preference: %s', 'plugin-check' ),
+					$e->getMessage()
+				)
+			);
 		}
-
-		return $result ? $result : $builder;
 	}
 
 	/**
@@ -249,7 +246,7 @@ trait AI_Check_Names {
 			if ( false !== strpos( $trimmed, $separator ) ) {
 				list( $provider, $model ) = array_map( 'trim', explode( $separator, $trimmed, 2 ) );
 				if ( '' !== $provider && '' !== $model ) {
-					return array( array( $provider, $model ) );
+					return array( $provider, $model );
 				}
 			}
 		}


### PR DESCRIPTION
The model preference was not being applied due to two issues:

1. method_exists() check was failing because WP_AI_Client_Prompt_Builder
   uses magic __call() method. Changed to directly call the method with
   try-catch error handling instead.

2. normalize_model_preference() was returning a nested array
   [['provider', 'model']] instead of the expected ['provider', 'model']
   format. Removed the extra array wrapper.

This ensures that when users specify a model preference like
'openai::gpt-5.4-pro', it is correctly passed to the WordPress AI
client instead of falling back to the default model.

Fixes #1212


## Issue Video:


https://github.com/user-attachments/assets/5cc81dc1-3ab8-498e-928a-7a3b43a68bce


## Video after adding the patch

https://github.com/user-attachments/assets/6c874309-9d1e-4a94-85a1-2afd6212759c





