### PR TITLE
Use latest stable WP version for wp-since generation

### DIFF
--- a/.github/workflows/generate-wp-functions-since-data.yml
+++ b/.github/workflows/generate-wp-functions-since-data.yml
@@ -21,6 +21,10 @@ jobs:
         id: wp
         run: |
           VERSION=$(curl -fsSL 'https://api.wordpress.org/core/version-check/1.7/' | jq -r '.offers[0].version')
+          if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+            echo "::error::Failed to resolve WordPress version from API"
+            exit 1
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Using WordPress $VERSION (latest stable from WordPress.org)"
 

--- a/.github/workflows/generate-wp-functions-since-data.yml
+++ b/.github/workflows/generate-wp-functions-since-data.yml
@@ -17,10 +17,18 @@ jobs:
       - name: Checkout plugin-check
         uses: actions/checkout@v6
 
+      - name: Resolve latest stable WordPress version
+        id: wp
+        run: |
+          VERSION=$(curl -fsSL 'https://api.wordpress.org/core/version-check/1.7/' | jq -r '.offers[0].version')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Using WordPress $VERSION (latest stable from WordPress.org)"
+
       - name: Checkout WordPress core
         uses: actions/checkout@v6
         with:
           repository: WordPress/WordPress
+          ref: ${{ steps.wp.outputs.version }}
           path: wordpress-core
 
       - name: Set up PHP


### PR DESCRIPTION

**What**

The "Generate WP Functions Since Data" workflow was checking out `WordPress/WordPress` with no `ref`, so it used the default branch instead of a **stable** release.


**Change**

- Resolve the current stable version from the WordPress.org version-check API: `https://api.wordpress.org/core/version-check/1.7/`
- Check out the matching release tag for that version so the generated `@since` dataset reflects **latest stable** core.
