### PR TITLE
Adjust checks for update mode

### DIFF
--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
@@ -515,7 +515,7 @@ class Plugin_Header_Fields_Check implements Static_Check {
 
 				$target_path = wp_normalize_path( $result->plugin()->path() . $domain_path );
 
-				if ( ! is_dir( $target_path ) ) {
+				if ( ! is_dir( $target_path ) && $this->is_new_mode( $result ) ) {
 					$this->add_result_warning_for_file(
 						$result,
 						sprintf(

--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
@@ -14,6 +14,7 @@ use WordPress\Plugin_Check\Lib\Readme\Parser as PCPParser;
 use WordPress\Plugin_Check\Traits\Amend_Check_Result;
 use WordPress\Plugin_Check\Traits\Language_Utils;
 use WordPress\Plugin_Check\Traits\License_Utils;
+use WordPress\Plugin_Check\Traits\Mode_Aware;
 use WordPress\Plugin_Check\Traits\Readme_Utils;
 use WordPress\Plugin_Check\Traits\Stable_Check;
 use WordPress\Plugin_Check\Traits\URL_Utils;
@@ -31,6 +32,7 @@ use WordPressdotorg\Plugin_Directory\Readme\Parser as DotorgParser;
 class Plugin_Readme_Check extends Abstract_File_Check {
 
 	use Amend_Check_Result;
+	use Mode_Aware;
 	use Readme_Utils;
 	use Stable_Check;
 	use License_Utils;
@@ -256,22 +258,38 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 						}
 
 						if ( version_compare( $tested_upto_major, $latest_wordpress_version, '<' ) ) {
-							$this->add_result_error_for_file(
-								$result,
-								sprintf(
-									/* translators: 1: currently used version, 2: latest stable WordPress version, 3: 'Tested up to' */
-									__( '<strong>Tested up to: %1$s &lt; %2$s.</strong><br>The "%3$s" value in your plugin is not set to the current version of WordPress. This means your plugin will not show up in searches, as we require plugins to be compatible and documented as tested up to the most recent version of WordPress.', 'plugin-check' ),
-									$tested_upto_major,
-									$latest_wordpress_version,
-									'Tested up to'
-								),
-								'outdated_tested_upto_header',
-								$readme_file,
-								0,
-								0,
-								'https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/#readme-header-information',
-								7
+							$outdated_tested_message = sprintf(
+								/* translators: 1: currently used version, 2: latest stable WordPress version, 3: 'Tested up to' */
+								__( '<strong>Tested up to: %1$s &lt; %2$s.</strong><br>The "%3$s" value in your plugin is not set to the current version of WordPress. This means your plugin will not show up in searches, as we require plugins to be compatible and documented as tested up to the most recent version of WordPress.', 'plugin-check' ),
+								$tested_upto_major,
+								$latest_wordpress_version,
+								'Tested up to'
 							);
+							$outdated_tested_docs = 'https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/#readme-header-information';
+
+							if ( $this->is_update_mode( $result ) ) {
+								$this->add_result_warning_for_file(
+									$result,
+									$outdated_tested_message,
+									'outdated_tested_upto_header',
+									$readme_file,
+									0,
+									0,
+									$outdated_tested_docs,
+									5
+								);
+							} else {
+								$this->add_result_error_for_file(
+									$result,
+									$outdated_tested_message,
+									'outdated_tested_upto_header',
+									$readme_file,
+									0,
+									0,
+									$outdated_tested_docs,
+									7
+								);
+							}
 						} elseif ( version_compare( $tested_upto_major, number_format( (float) $latest_wordpress_version + 0.1, 1 ), '>' ) ) {
 							$this->add_result_error_for_file(
 								$result,

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php
@@ -41,6 +41,27 @@ class Plugin_Header_Fields_Check_Tests extends WP_UnitTestCase {
 		}
 	}
 
+	public function test_plugin_header_nonexistent_domain_path_skipped_in_update_mode() {
+		$check         = new Plugin_Header_Fields_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-header-fields-with-errors/load.php', '', 'update' );
+		$check_result  = new Check_Result( $check_context );
+
+		$check->run( $check_result );
+
+		$warnings = $check_result->get_warnings();
+
+		$this->assertArrayHasKey( 'load.php', $warnings, 'Fixture should still emit warnings for the main plugin file in update mode.' );
+		$this->assertCount(
+			1,
+			wp_list_filter( $warnings['load.php'][0][0], array( 'code' => 'textdomain_mismatch' ) ),
+			'Unrelated warnings must still run so we know the check executed (same fixture as test_run_with_errors).'
+		);
+		$this->assertCount(
+			0,
+			wp_list_filter( $warnings['load.php'][0][0], array( 'code' => 'plugin_header_nonexistent_domain_path' ) )
+		);
+	}
+
 	public function test_run_with_invalid_requires_wp_header() {
 		set_transient( 'wp_plugin_check_latest_version_info', array( 'current' => '6.5.1' ) );
 

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
@@ -203,21 +203,50 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 	}
 
 	public function test_run_with_errors_tested_upto() {
+		set_transient( 'wp_plugin_check_latest_version_info', array( 'current' => '6.5.0' ) );
+
 		$readme_check  = new Plugin_Readme_Check();
 		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-readme-errors-tested-upto/load.php' );
 		$check_result  = new Check_Result( $check_context );
 
 		$readme_check->run( $check_result );
 
-		$errors = $check_result->get_errors();
+		delete_transient( 'wp_plugin_check_latest_version_info' );
+
+		$errors   = $check_result->get_errors();
+		$warnings = $check_result->get_warnings();
 
 		$this->assertNotEmpty( $errors );
 		$this->assertArrayHasKey( 'readme.txt', $errors );
 
-		// Check for tested upto.
+		// Check for tested upto (default mode is new).
 		$this->assertArrayHasKey( 0, $errors['readme.txt'] );
 		$this->assertArrayHasKey( 0, $errors['readme.txt'][0] );
-		$this->assertCount( 1, wp_list_filter( $errors['readme.txt'][0][0], array( 'code' => 'outdated_tested_upto_header' ) ) );
+		$error_items = wp_list_filter( $errors['readme.txt'][0][0], array( 'code' => 'outdated_tested_upto_header' ) );
+		$this->assertCount( 1, $error_items );
+		$this->assertSame( 7, reset( $error_items )['severity'] );
+		$this->assertCount( 0, wp_list_filter( $warnings['readme.txt'][0][0] ?? array(), array( 'code' => 'outdated_tested_upto_header' ) ) );
+	}
+
+	public function test_outdated_tested_upto_header_reported_as_warning_in_update_mode() {
+		set_transient( 'wp_plugin_check_latest_version_info', array( 'current' => '6.5.0' ) );
+
+		$readme_check  = new Plugin_Readme_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-readme-errors-tested-upto/load.php', '', 'update' );
+		$check_result  = new Check_Result( $check_context );
+
+		$readme_check->run( $check_result );
+
+		delete_transient( 'wp_plugin_check_latest_version_info' );
+
+		$errors   = $check_result->get_errors();
+		$warnings = $check_result->get_warnings();
+
+		$this->assertCount( 0, wp_list_filter( $errors['readme.txt'][0][0] ?? array(), array( 'code' => 'outdated_tested_upto_header' ) ) );
+
+		$warning_items = wp_list_filter( $warnings['readme.txt'][0][0] ?? array(), array( 'code' => 'outdated_tested_upto_header' ) );
+		$this->assertCount( 1, $warning_items );
+		$this->assertSame( 5, reset( $warning_items )['severity'] );
 	}
 
 	public function test_run_with_errors_tested_upto_minor_same_major_version() {


### PR DESCRIPTION
Fixes https://github.com/WordPress/plugin-check/issues/1286

**Summary:** In **update** mode only, two checks are relaxed; **new** mode behavior is unchanged.

**Code**

| Check | New mode | Update mode |
|--------|-----------|-------------|
| `outdated_tested_upto_header` | `ERROR`, severity 7 | `WARNING`, severity 5 |
| `plugin_header_nonexistent_domain_path` | Same as today (warning, severity 6) | Not run (`is_new_mode()` gate) |

Files: `includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php`, `includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php`.