### PR TITLE
Allow WordPress.org `Update URI` when slug matches plugin directory

### DIFF
--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Updater_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Updater_Check.php
@@ -98,7 +98,11 @@ class Plugin_Updater_Check extends Abstract_File_Check {
 	}
 
 	/**
-	 * Looks for UpdateURI in plugin header and amends the given result with an error if found.
+	 * Looks for UpdateURI in plugin header and amends the given result with an error if invalid.
+	 *
+	 * Plugins on WordPress.org should not use this header, but the same URI formats as in the
+	 * directory API are accepted here: a wordpress.org or w.org plugin URL whose slug matches
+	 * this plugin passes; any other value is flagged.
 	 *
 	 * @since 1.0.0
 	 *
@@ -110,19 +114,34 @@ class Plugin_Updater_Check extends Abstract_File_Check {
 		}
 
 		$plugin_main_file = $result->plugin()->main_file();
+		$plugin_slug      = $result->plugin()->slug();
 		$plugin_header    = get_plugin_data( $plugin_main_file );
-		if ( ! empty( $plugin_header['UpdateURI'] ) ) {
-			$this->add_result_error_for_file(
-				$result,
-				__( '<strong>Including An Update Checker / Changing Updates functionality.</strong><br>Plugin Updater detected. Use of the Update URI header is not allowed in plugins hosted on WordPress.org.', 'plugin-check' ),
-				'plugin_updater_detected',
-				$plugin_main_file,
-				0,
-				0,
-				'https://developer.wordpress.org/plugins/wordpress-org/common-issues/#update-checker',
-				9
-			);
+
+		if ( empty( $plugin_header['UpdateURI'] ) ) {
+			return;
 		}
+
+		$update_uri_matches = array();
+		$update_uri_valid   = (bool) preg_match(
+			'!^(https?://)?(wordpress.org|w.org)/plugins?/(?P<slug>[^/]+)/?$!i',
+			$plugin_header['UpdateURI'],
+			$update_uri_matches
+		);
+
+		if ( $update_uri_valid && isset( $update_uri_matches['slug'] ) && $update_uri_matches['slug'] === $plugin_slug ) {
+			return;
+		}
+
+		$this->add_result_error_for_file(
+			$result,
+			__( '<strong>Including An Update Checker / Changing Updates functionality.</strong><br>Plugin Updater detected. Use of the Update URI header is not allowed in plugins hosted on WordPress.org.', 'plugin-check' ),
+			'plugin_updater_detected',
+			$plugin_main_file,
+			0,
+			0,
+			'https://developer.wordpress.org/plugins/wordpress-org/common-issues/#update-checker',
+			9
+		);
 	}
 
 	/**

--- a/tests/phpunit/testdata/plugins/test-plugin-update-uri-w-org-ok/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-update-uri-w-org-ok/load.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Plugin Name: Test Plugin Update URI WordPress.org OK
+ * Plugin URI: https://github.com/WordPress/plugin-check
+ * Description: Update URI matches the plugin WordPress.org listing (allowed).
+ * Requires at least: 6.0
+ * Requires PHP: 5.6
+ * Version: 1.0.0
+ * Author: WordPress Performance Team
+ * Author URI: https://make.wordpress.org/performance/
+ * License: GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ * Text Domain: test-plugin-update-uri-w-org-ok
+ * Update URI: https://wordpress.org/plugins/test-plugin-update-uri-w-org-ok/
+ *
+ * @package test-plugin-update-uri-w-org-ok
+ */

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Updater_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Updater_Check_Tests.php
@@ -122,4 +122,18 @@ class Plugin_Updater_Check_Tests extends WP_UnitTestCase {
 		$this->assertEquals( 0, $check_result->get_error_count() );
 		$this->assertEquals( 0, $check_result->get_warning_count() );
 	}
+
+	/**
+	 * Update URI may point at this plugin’s WordPress.org URL; that must not be flagged.
+	 */
+	public function test_run_update_uri_wordpress_org_matching_slug_no_error() {
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-update-uri-w-org-ok/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$check = new Plugin_Updater_Check( Plugin_Updater_Check::TYPE_PLUGIN_UPDATE_URI_HEADER );
+		$check->run( $check_result );
+
+		$this->assertEmpty( $check_result->get_errors() );
+		$this->assertSame( 0, $check_result->get_error_count() );
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/WordPress/plugin-check/issues/1287

Relaxes `Plugin_Updater_Check` so the `Update URI` header is not flagged when it matches the same URL patterns accepted by the plugin directory API: `wordpress.org` or `w.org`, `/plugin(s)/…`, and the path slug matches the plugin slug. Any other value still reports `plugin_updater_detected`.