### PR TITLE
Add action hooks to Runtime_Environment_Setup

### DIFF
--- a/includes/Checker/Runtime_Environment_Setup.php
+++ b/includes/Checker/Runtime_Environment_Setup.php
@@ -24,9 +24,24 @@ final class Runtime_Environment_Setup {
 	 *
 	 * @global wpdb               $wpdb          WordPress database abstraction object.
 	 * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
+	 *
+	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
 	 */
 	public function set_up() {
 		global $wpdb, $wp_filesystem;
+
+		/**
+		 * Fires before the runtime environment is set up.
+		 *
+		 * @since 2.0.0
+		 *
+		 * @param array $context {
+		 *     Context for the hook.
+		 *
+		 *     @type bool $early_exit Whether the method exited before completing all setup steps.
+		 * }
+		 */
+		do_action( 'wp_plugin_check_before_runtime_setup', array( 'early_exit' => false ) );
 
 		require_once ABSPATH . '/wp-admin/includes/upgrade.php';
 
@@ -82,6 +97,18 @@ final class Runtime_Environment_Setup {
 
 		// Return early if the plugin check object cache already exists.
 		if ( defined( 'WP_PLUGIN_CHECK_OBJECT_CACHE_DROPIN_VERSION' ) && WP_PLUGIN_CHECK_OBJECT_CACHE_DROPIN_VERSION ) {
+			/**
+			 * Fires after the runtime environment is set up, including when it exits early.
+			 *
+			 * @since 2.0.0
+			 *
+			 * @param array $context {
+			 *     Context for the hook.
+			 *
+			 *     @type bool $early_exit Whether the method exited before completing all setup steps.
+			 * }
+			 */
+			do_action( 'wp_plugin_check_after_runtime_setup', array( 'early_exit' => true ) );
 			return;
 		}
 
@@ -92,6 +119,19 @@ final class Runtime_Environment_Setup {
 				$wp_filesystem->copy( WP_PLUGIN_CHECK_PLUGIN_DIR_PATH . 'drop-ins/object-cache.copy.php', WP_CONTENT_DIR . '/object-cache.php' );
 			}
 		}
+
+		/**
+		 * Fires after the runtime environment is set up, including when it exits early.
+		 *
+		 * @since 2.0.0
+		 *
+		 * @param array $context {
+		 *     Context for the hook.
+		 *
+		 *     @type bool $early_exit Whether the method exited before completing all setup steps.
+		 * }
+		 */
+		do_action( 'wp_plugin_check_after_runtime_setup', array( 'early_exit' => false ) );
 	}
 
 	/**
@@ -104,6 +144,19 @@ final class Runtime_Environment_Setup {
 	 */
 	public function clean_up() {
 		global $wpdb, $wp_filesystem;
+
+		/**
+		 * Fires before the runtime environment is cleaned up.
+		 *
+		 * @since 2.0.0
+		 *
+		 * @param array $context {
+		 *     Context for the hook.
+		 *
+		 *     @type bool $early_exit Whether the method exited before completing all cleanup steps.
+		 * }
+		 */
+		do_action( 'wp_plugin_check_before_runtime_cleanup', array( 'early_exit' => false ) );
 
 		require_once ABSPATH . '/wp-admin/includes/upgrade.php';
 
@@ -121,12 +174,36 @@ final class Runtime_Environment_Setup {
 
 		// Return early if the plugin check object cache does not exist.
 		if ( ! defined( 'WP_PLUGIN_CHECK_OBJECT_CACHE_DROPIN_VERSION' ) || ! WP_PLUGIN_CHECK_OBJECT_CACHE_DROPIN_VERSION ) {
+			/**
+			 * Fires after the runtime environment is cleaned up, including when it exits early.
+			 *
+			 * @since 2.0.0
+			 *
+			 * @param array $context {
+			 *     Context for the hook.
+			 *
+			 *     @type bool $early_exit Whether the method exited before completing all cleanup steps.
+			 * }
+			 */
+			do_action( 'wp_plugin_check_after_runtime_cleanup', array( 'early_exit' => true ) );
 			return;
 		}
 
 		// Remove the object-cache.php file.
 		if ( $wp_filesystem || WP_Filesystem() ) {
 			if ( ! $wp_filesystem->exists( WP_CONTENT_DIR . '/object-cache.php' ) ) {
+				/**
+				 * Fires after the runtime environment is cleaned up, including when it exits early.
+				 *
+				 * @since 2.0.0
+				 *
+				 * @param array $context {
+				 *     Context for the hook.
+				 *
+				 *     @type bool $early_exit Whether the method exited before completing all cleanup steps.
+				 * }
+				 */
+				do_action( 'wp_plugin_check_after_runtime_cleanup', array( 'early_exit' => true ) );
 				return;
 			}
 
@@ -138,6 +215,19 @@ final class Runtime_Environment_Setup {
 				$wp_filesystem->delete( WP_CONTENT_DIR . '/object-cache.php' );
 			}
 		}
+
+		/**
+		 * Fires after the runtime environment is cleaned up, including when it exits early.
+		 *
+		 * @since 2.0.0
+		 *
+		 * @param array $context {
+		 *     Context for the hook.
+		 *
+		 *     @type bool $early_exit Whether the method exited before completing all cleanup steps.
+		 * }
+		 */
+		do_action( 'wp_plugin_check_after_runtime_cleanup', array( 'early_exit' => false ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/Checker/Runtime_Environment_Setup_Tests.php
+++ b/tests/phpunit/tests/Checker/Runtime_Environment_Setup_Tests.php
@@ -92,6 +92,88 @@ class Runtime_Environment_Setup_Tests extends WP_UnitTestCase {
 		$this->assertFalse( $runtime_setup->can_set_up() );
 	}
 
+	public function test_before_runtime_setup_action_fires() {
+		$this->set_up_mock_filesystem();
+
+		$fired   = false;
+		$context = null;
+		add_action(
+			'wp_plugin_check_before_runtime_setup',
+			function ( $ctx ) use ( &$fired, &$context ) {
+				$fired   = true;
+				$context = $ctx;
+			}
+		);
+
+		$runtime_setup = new Runtime_Environment_Setup();
+		$runtime_setup->set_up();
+
+		$this->assertTrue( $fired );
+		$this->assertIsArray( $context );
+		$this->assertArrayHasKey( 'early_exit', $context );
+		$this->assertFalse( $context['early_exit'] );
+	}
+
+	public function test_after_runtime_setup_action_fires() {
+		$this->set_up_mock_filesystem();
+
+		$fired   = false;
+		$context = null;
+		add_action(
+			'wp_plugin_check_after_runtime_setup',
+			function ( $ctx ) use ( &$fired, &$context ) {
+				$fired   = true;
+				$context = $ctx;
+			}
+		);
+
+		$runtime_setup = new Runtime_Environment_Setup();
+		$runtime_setup->set_up();
+
+		$this->assertTrue( $fired );
+		$this->assertIsArray( $context );
+		$this->assertArrayHasKey( 'early_exit', $context );
+	}
+
+	public function test_before_runtime_cleanup_action_fires() {
+		$fired   = false;
+		$context = null;
+		add_action(
+			'wp_plugin_check_before_runtime_cleanup',
+			function ( $ctx ) use ( &$fired, &$context ) {
+				$fired   = true;
+				$context = $ctx;
+			}
+		);
+
+		$runtime_setup = new Runtime_Environment_Setup();
+		$runtime_setup->clean_up();
+
+		$this->assertTrue( $fired );
+		$this->assertIsArray( $context );
+		$this->assertArrayHasKey( 'early_exit', $context );
+		$this->assertFalse( $context['early_exit'] );
+	}
+
+	public function test_after_runtime_cleanup_action_fires() {
+		$fired   = false;
+		$context = null;
+		add_action(
+			'wp_plugin_check_after_runtime_cleanup',
+			function ( $ctx ) use ( &$fired, &$context ) {
+				$fired   = true;
+				$context = $ctx;
+			}
+		);
+
+		$runtime_setup = new Runtime_Environment_Setup();
+		$runtime_setup->clean_up();
+
+		$this->assertTrue( $fired );
+		$this->assertIsArray( $context );
+		$this->assertArrayHasKey( 'early_exit', $context );
+	}
+
 	public function test_clean_up() {
 		global $wp_filesystem, $wpdb, $table_prefix;
 


### PR DESCRIPTION

Closes https://github.com/WordPress/plugin-check/issues/1269

Adds four `do_action()` hooks to `Runtime_Environment_Setup` so integrations can observe or react to the isolated DB / object-cache boundary without patching core logic.

## Description


| Hook | Fires |
|---|---|
| `wp_plugin_check_before_runtime_setup` | Before `set_up()` mutates state |
| `wp_plugin_check_after_runtime_setup` | After `set_up()` completes (including early-exit path) |
| `wp_plugin_check_before_runtime_cleanup` | Before `clean_up()` mutates state |
| `wp_plugin_check_after_runtime_cleanup` | After `clean_up()` completes (including both early-exit paths) |

Each hook receives a single `array $context` argument with one key: `early_exit` (`bool`) — `true` when the method returned before completing all steps.

## Changes


- `includes/Checker/Runtime_Environment_Setup.php` — `do_action()` calls added.
- `tests/phpunit/tests/Checker/Runtime_Environment_Setup_Tests.php` — new test methods.


## AI Usage Disclosure

- [ ] This PR was created without the help of AI tools
- [x] This PR includes AI-assisted code or content

Used:
- Claude
