### PR TITLE
Improve documentation clarity for WP-CLI runtime checks and path/URL grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ After having the plugin activated, you can analyze any other plugin installed on
 
 * To check a plugin using WP Admin, please navigate to the _Tools > Plugin Check_ menu. You need to be able to manage plugins on your site in order to access that screen.
 * To check a plugin using WP-CLI, please use the `wp plugin check` command. For example, to check the "Hello Dolly" plugin: `wp plugin check hello.php`
-    * Note that by default when using WP-CLI, only static checks can be executed. In order to also include runtime checks, a workaround is currently necessary using the `--require` argument of WP-CLI, to manually load the `cli.php` file within the plugin checker directory before WordPress is loaded. For example: `wp plugin check hello.php --require=./wp-content/plugins/plugin-check/cli.php`
+    * Note that by default when using WP-CLI, only static checks can be executed. In order to also include runtime checks, a workaround is currently required: use the `--require` argument to manually load `cli.php` from the plugin checker directory before WordPress loads.. For example: `wp plugin check hello.php --require=./wp-content/plugins/plugin-check/cli.php`
     * You could use arbitrary path or URL to check a plugin. For example, to check a plugin from a URL: `wp plugin check https://example.com/plugin.zip` or to check a plugin from a path: `wp plugin check /path/to/plugin`
 
 <img alt="WordPress plugin checker UI in WP Admin" src="https://github.com/WordPress/plugin-check/assets/3531426/19d0c1ce-8c37-4efd-b8c6-d252e6ce29c9">

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ After having the plugin activated, you can analyze any other plugin installed on
 
 * To check a plugin using WP Admin, please navigate to the _Tools > Plugin Check_ menu. You need to be able to manage plugins on your site in order to access that screen.
 * To check a plugin using WP-CLI, please use the `wp plugin check` command. For example, to check the "Hello Dolly" plugin: `wp plugin check hello.php`
-    * Note that by default when using WP-CLI, only static checks can be executed. In order to also include runtime checks, a workaround is currently required: use the `--require` argument to manually load `cli.php` from the plugin checker directory before WordPress loads.. For example: `wp plugin check hello.php --require=./wp-content/plugins/plugin-check/cli.php`
-    * You could use arbitrary path or URL to check a plugin. For example, to check a plugin from a URL: `wp plugin check https://example.com/plugin.zip` or to check a plugin from a path: `wp plugin check /path/to/plugin`
+    * Note that by default when using WP-CLI, only static checks can be executed. In order to also include runtime checks, a workaround is currently required: use the `--require` argument to manually load `cli.php` from the plugin checker directory before WordPress loads. For example: `wp plugin check hello.php --require=./wp-content/plugins/plugin-check/cli.php`
+    * You can use an arbitrary path or URL to check a plugin. For example, to check a plugin from a URL: `wp plugin check https://example.com/plugin.zip` or to check a plugin from a path: `wp plugin check /path/to/plugin`
 
 <img alt="WordPress plugin checker UI in WP Admin" src="https://github.com/WordPress/plugin-check/assets/3531426/19d0c1ce-8c37-4efd-b8c6-d252e6ce29c9">
 <em>Screenshot of the plugin checker's UI in WP Admin</em>


### PR DESCRIPTION
## What?
This PR improves two documentation sentences of the plugin checker:
1. Clarifies the wording of the WP-CLI runtime checks workaround.
2. Fixes a minor grammar issue in the sentence about using an arbitrary path or URL.

## Why?
The original phrasing for the runtime checks workaround was somewhat awkward and could be clearer about the required action. The grammar issue (missing "an" and using "could" instead of "can") makes the documentation less professional and slightly harder to read. These changes improve clarity, conciseness, and correctness without altering any technical meaning.

## How?
**Change 3 (runtime checks workaround):**
- Reworded from: *"a workaround is currently necessary using the --require argument of WP-CLI, to manually load the cli.php file within the plugin checker directory before WordPress is loaded."*
- To: *"a workaround is currently required: use the --require argument to manually load cli.php from the plugin checker directory **before** WordPress loads."*

**Change 4 (path/URL grammar):**
- Changed from: *"You could use arbitrary path or URL to check a plugin."*
- To: *"You can use an arbitrary path or URL to check a plugin."*

Both changes are purely editorial with no functional impact.

## Testing Instructions
1. Read the updated documentation section.
2. Verify that the WP-CLI workaround explanation is clearer and still technically accurate.
3. Verify that the path/URL sentence now reads naturally and includes the missing article "an".
4. Confirm no technical information was lost or altered.

## AI Usage Disclosure
<!-- See the WordPress AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/ -->

- [ ] This PR was created without the help of AI tools
- [x] This PR includes AI-assisted code or content

If AI tools were used, please describe how they were used:
Used ChatGPT Plus to help rephrase the runtime checks workaround for clarity and to identify the missing article/grammar issue in the path/URL sentence. All changes were reviewed for technical accuracy.

| Before | After |
|--------|-------|
| *"a workaround is currently necessary using the --require argument of WP-CLI, to manually load the cli.php file within the plugin checker directory before WordPress is loaded."* | *"a workaround is currently required: use the --require argument to manually load cli.php from the plugin checker directory **before** WordPress loads."* |
| *"You could use arbitrary path or URL to check a plugin."* | *"You can use an arbitrary path or URL to check a plugin."* |
