### PR TITLE
Add setup/cleanup hooks and bootstrap-file extension point

### DIFF
--- a/cli.php
+++ b/cli.php
@@ -28,6 +28,31 @@ if ( ! class_exists( 'WordPress\Plugin_Check\CLI\Plugin_Check_Command' ) ) {
 	require_once __DIR__ . '/vendor/autoload.php';
 }
 
+/*
+ * Load the consumer-supplied bootstrap file (if configured) before the command is registered.
+ * This mirrors the behaviour of the `object-cache.php` drop-in so that integrations have one
+ * consistent extension point across admin and WP-CLI paths.
+ *
+ * The constant is expected to hold an absolute filesystem path. When the constant is defined
+ * but the file is missing, a WP-CLI warning is emitted and execution continues.
+ */
+if ( defined( 'WP_PLUGIN_CHECK_BOOTSTRAP_FILE' ) ) {
+	$plugin_check_bootstrap_file = WP_PLUGIN_CHECK_BOOTSTRAP_FILE;
+	if ( is_string( $plugin_check_bootstrap_file ) && '' !== $plugin_check_bootstrap_file ) {
+		if ( is_file( $plugin_check_bootstrap_file ) ) {
+			require_once $plugin_check_bootstrap_file;
+		} else {
+			WP_CLI::warning(
+				sprintf(
+					'Plugin Check: WP_PLUGIN_CHECK_BOOTSTRAP_FILE points to "%s", but the file does not exist.',
+					$plugin_check_bootstrap_file
+				)
+			);
+		}
+	}
+	unset( $plugin_check_bootstrap_file );
+}
+
 if ( ! isset( $context ) ) {
 	$context = new Plugin_Context( __DIR__ . '/plugin.php' );
 }

--- a/drop-ins/object-cache.copy.php
+++ b/drop-ins/object-cache.copy.php
@@ -34,6 +34,32 @@ function plugin_check_initialize_runner() {
 
 	require_once $plugin_dir . 'vendor/autoload.php';
 
+	/*
+	 * Load the consumer-supplied bootstrap file (if configured) before the runner is initialized.
+	 * The bootstrap file is the earliest point at which an integration can register listeners for
+	 * plugin-check actions/filters, since this drop-in runs before mu-plugins.
+	 *
+	 * The constant is expected to hold an absolute filesystem path. When the constant is defined
+	 * but the file is missing, a PHP warning is emitted so that misconfiguration is visible; PCP
+	 * keeps running regardless.
+	 */
+	if ( defined( 'WP_PLUGIN_CHECK_BOOTSTRAP_FILE' ) ) {
+		$plugin_check_bootstrap_file = WP_PLUGIN_CHECK_BOOTSTRAP_FILE;
+		if ( is_string( $plugin_check_bootstrap_file ) && '' !== $plugin_check_bootstrap_file ) {
+			if ( is_file( $plugin_check_bootstrap_file ) ) {
+				require_once $plugin_check_bootstrap_file;
+			} else {
+				trigger_error(
+					sprintf(
+						'Plugin Check: WP_PLUGIN_CHECK_BOOTSTRAP_FILE points to "%s", but the file does not exist.',
+						$plugin_check_bootstrap_file
+					),
+					E_USER_WARNING
+				);
+			}
+		}
+	}
+
 	if ( class_exists( 'WordPress\Plugin_Check\Utilities\Plugin_Request_Utility' ) ) {
 		// Initialize the Check Runner class based on the request.
 		WordPress\Plugin_Check\Utilities\Plugin_Request_Utility::initialize_runner();

--- a/includes/Checker/Runtime_Environment_Setup.php
+++ b/includes/Checker/Runtime_Environment_Setup.php
@@ -28,69 +28,93 @@ final class Runtime_Environment_Setup {
 	public function set_up() {
 		global $wpdb, $wp_filesystem;
 
-		require_once ABSPATH . '/wp-admin/includes/upgrade.php';
+		/**
+		 * Fires before the plugin-check runtime environment is set up.
+		 *
+		 * @since 1.10.0
+		 *
+		 * @param Runtime_Environment_Setup $environment_setup Environment-setup instance.
+		 */
+		do_action( 'wp_plugin_check_before_setup_environment', $this );
 
-		// Get the existing site URL.
-		$site_url = get_option( 'siteurl' );
+		try {
+			require_once ABSPATH . '/wp-admin/includes/upgrade.php';
 
-		// Get the existing active plugins.
-		$active_plugins = get_option( 'active_plugins' );
+			// Get the existing site URL.
+			$site_url = get_option( 'siteurl' );
 
-		// Get the existing active theme.
-		$active_theme = get_option( 'stylesheet' );
+			// Get the existing active plugins.
+			$active_plugins = get_option( 'active_plugins' );
 
-		// Get the existing permalink structure.
-		$permalink_structure = get_option( 'permalink_structure' );
+			// Get the existing active theme.
+			$active_theme = get_option( 'stylesheet' );
 
-		// Set the new prefix.
-		$prefix_cleanup = $this->amend_db_base_prefix();
+			// Get the existing permalink structure.
+			$permalink_structure = get_option( 'permalink_structure' );
 
-		// Create and populate the test database tables if they do not exist.
-		if ( $wpdb->posts !== $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $wpdb->posts ) ) ) {
-			/*
-			 * Set the same permalink structure *before* install finishes,
-			 * so that wp_install_maybe_enable_pretty_permalinks() does not flush rewrite rules.
-			 *
-			 * See https://github.com/WordPress/plugin-check/issues/330
-			 */
-			add_action(
-				'populate_options',
-				static function () use ( $permalink_structure ) {
-					/*
-					 * If pretty permalinks are not used, temporarily enable them by setting a permalink structure, to
-					 * avoid flushing rewrite rules in wp_install_maybe_enable_pretty_permalinks().
-					 * Afterwards, on the 'wp_install' action, set the original (empty) permalink structure.
-					 */
-					if ( ! $permalink_structure ) {
-						add_action(
-							'wp_install',
-							static function () use ( $permalink_structure ) {
-								update_option( 'permalink_structure', $permalink_structure );
-							}
-						);
-						$permalink_structure = '/%postname%/';
+			// Set the new prefix.
+			$prefix_cleanup = $this->amend_db_base_prefix();
+
+			// Create and populate the test database tables if they do not exist.
+			if ( $wpdb->posts !== $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $wpdb->posts ) ) ) {
+				/*
+				 * Set the same permalink structure *before* install finishes,
+				 * so that wp_install_maybe_enable_pretty_permalinks() does not flush rewrite rules.
+				 *
+				 * See https://github.com/WordPress/plugin-check/issues/330
+				 */
+				add_action(
+					'populate_options',
+					static function () use ( $permalink_structure ) {
+						/*
+						 * If pretty permalinks are not used, temporarily enable them by setting a permalink structure, to
+						 * avoid flushing rewrite rules in wp_install_maybe_enable_pretty_permalinks().
+						 * Afterwards, on the 'wp_install' action, set the original (empty) permalink structure.
+						 */
+						if ( ! $permalink_structure ) {
+							add_action(
+								'wp_install',
+								static function () use ( $permalink_structure ) {
+									update_option( 'permalink_structure', $permalink_structure );
+								}
+							);
+							$permalink_structure = '/%postname%/';
+						}
+						add_option( 'permalink_structure', $permalink_structure );
 					}
-					add_option( 'permalink_structure', $permalink_structure );
-				}
-			);
+				);
 
-			$this->install_wordpress( $site_url, $active_theme, $active_plugins );
-		}
-
-		// Restore the old prefix.
-		$prefix_cleanup();
-
-		// Return early if the plugin check object cache already exists.
-		if ( defined( 'WP_PLUGIN_CHECK_OBJECT_CACHE_DROPIN_VERSION' ) && WP_PLUGIN_CHECK_OBJECT_CACHE_DROPIN_VERSION ) {
-			return;
-		}
-
-		// Create the object-cache.php file.
-		if ( $wp_filesystem || WP_Filesystem() ) {
-			// Do not replace the object-cache.php file if it already exists.
-			if ( ! $wp_filesystem->exists( WP_CONTENT_DIR . '/object-cache.php' ) ) {
-				$wp_filesystem->copy( WP_PLUGIN_CHECK_PLUGIN_DIR_PATH . 'drop-ins/object-cache.copy.php', WP_CONTENT_DIR . '/object-cache.php' );
+				$this->install_wordpress( $site_url, $active_theme, $active_plugins );
 			}
+
+			// Restore the old prefix.
+			$prefix_cleanup();
+
+			// Return early if the plugin check object cache already exists.
+			if ( defined( 'WP_PLUGIN_CHECK_OBJECT_CACHE_DROPIN_VERSION' ) && WP_PLUGIN_CHECK_OBJECT_CACHE_DROPIN_VERSION ) {
+				return;
+			}
+
+			// Create the object-cache.php file.
+			if ( $wp_filesystem || WP_Filesystem() ) {
+				// Do not replace the object-cache.php file if it already exists.
+				if ( ! $wp_filesystem->exists( WP_CONTENT_DIR . '/object-cache.php' ) ) {
+					$wp_filesystem->copy( WP_PLUGIN_CHECK_PLUGIN_DIR_PATH . 'drop-ins/object-cache.copy.php', WP_CONTENT_DIR . '/object-cache.php' );
+				}
+			}
+		} finally {
+			/**
+			 * Fires after the plugin-check runtime environment has been set up.
+			 *
+			 * This hook always fires once `set_up()` is entered, even when the method returned
+			 * early (for example, because the environment was already prepared). Subscribers can
+			 * call `$environment_setup->is_set_up()` to check the actual state.
+			 *
+			 * @since 1.10.0
+			 *
+			 * @param Runtime_Environment_Setup $environment_setup Environment-setup instance.
+			 */
+			do_action( 'wp_plugin_check_after_setup_environment', $this );
 		}
 	}
 
@@ -105,38 +129,61 @@ final class Runtime_Environment_Setup {
 	public function clean_up() {
 		global $wpdb, $wp_filesystem;
 
-		require_once ABSPATH . '/wp-admin/includes/upgrade.php';
+		/**
+		 * Fires before the plugin-check runtime environment is cleaned up.
+		 *
+		 * @since 1.10.0
+		 *
+		 * @param Runtime_Environment_Setup $environment_setup Environment-setup instance.
+		 */
+		do_action( 'wp_plugin_check_before_cleanup_environment', $this );
 
-		$prefix_cleanup = $this->amend_db_base_prefix();
-		$tables         = $wpdb->tables();
+		try {
+			require_once ABSPATH . '/wp-admin/includes/upgrade.php';
 
-		$tables = $this->ignore_custom_tables( $tables );
+			$prefix_cleanup = $this->amend_db_base_prefix();
+			$tables         = $wpdb->tables();
 
-		foreach ( $tables as $table ) {
-			$wpdb->query( "DROP TABLE IF EXISTS `$table`" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		}
+			$tables = $this->ignore_custom_tables( $tables );
 
-		// Restore the old prefix.
-		$prefix_cleanup();
+			foreach ( $tables as $table ) {
+				$wpdb->query( "DROP TABLE IF EXISTS `$table`" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			}
 
-		// Return early if the plugin check object cache does not exist.
-		if ( ! defined( 'WP_PLUGIN_CHECK_OBJECT_CACHE_DROPIN_VERSION' ) || ! WP_PLUGIN_CHECK_OBJECT_CACHE_DROPIN_VERSION ) {
-			return;
-		}
+			// Restore the old prefix.
+			$prefix_cleanup();
 
-		// Remove the object-cache.php file.
-		if ( $wp_filesystem || WP_Filesystem() ) {
-			if ( ! $wp_filesystem->exists( WP_CONTENT_DIR . '/object-cache.php' ) ) {
+			// Return early if the plugin check object cache does not exist.
+			if ( ! defined( 'WP_PLUGIN_CHECK_OBJECT_CACHE_DROPIN_VERSION' ) || ! WP_PLUGIN_CHECK_OBJECT_CACHE_DROPIN_VERSION ) {
 				return;
 			}
 
-			// Check the drop-in file matches the copy.
-			$original_content = $wp_filesystem->get_contents( WP_CONTENT_DIR . '/object-cache.php' );
-			$copy_content     = $wp_filesystem->get_contents( WP_PLUGIN_CHECK_PLUGIN_DIR_PATH . 'drop-ins/object-cache.copy.php' );
+			// Remove the object-cache.php file.
+			if ( $wp_filesystem || WP_Filesystem() ) {
+				if ( ! $wp_filesystem->exists( WP_CONTENT_DIR . '/object-cache.php' ) ) {
+					return;
+				}
 
-			if ( $original_content && $original_content === $copy_content ) {
-				$wp_filesystem->delete( WP_CONTENT_DIR . '/object-cache.php' );
+				// Check the drop-in file matches the copy.
+				$original_content = $wp_filesystem->get_contents( WP_CONTENT_DIR . '/object-cache.php' );
+				$copy_content     = $wp_filesystem->get_contents( WP_PLUGIN_CHECK_PLUGIN_DIR_PATH . 'drop-ins/object-cache.copy.php' );
+
+				if ( $original_content && $original_content === $copy_content ) {
+					$wp_filesystem->delete( WP_CONTENT_DIR . '/object-cache.php' );
+				}
 			}
+		} finally {
+			/**
+			 * Fires after the plugin-check runtime environment has been cleaned up.
+			 *
+			 * This hook always fires once `clean_up()` is entered, even when the method returned
+			 * early (for example, because the drop-in was not present).
+			 *
+			 * @since 1.10.0
+			 *
+			 * @param Runtime_Environment_Setup $environment_setup Environment-setup instance.
+			 */
+			do_action( 'wp_plugin_check_after_cleanup_environment', $this );
 		}
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,11 @@ In any case, passing the checks in this tool likely helps to achieve a smooth pl
 
 == Changelog ==
 
+= 1.10.0 =
+
+* Enhancement - Add `wp_plugin_check_before_setup_environment`, `wp_plugin_check_after_setup_environment`, `wp_plugin_check_before_cleanup_environment`, and `wp_plugin_check_after_cleanup_environment` actions around `Runtime_Environment_Setup::set_up()` and `clean_up()`.
+* Enhancement - Introduce the `WP_PLUGIN_CHECK_BOOTSTRAP_FILE` constant. When defined, the referenced file is loaded on the early-execution paths (`object-cache.php` drop-in and `cli.php`) so that integrations can register listeners for plugin-check hooks without patching generated drop-ins.
+
 = 1.9.0 =
 
 * Enhancement - Use the WordPress 7.0 core AI connectors.

--- a/tests/behat/features/plugin-check-bootstrap-file.feature
+++ b/tests/behat/features/plugin-check-bootstrap-file.feature
@@ -1,0 +1,47 @@
+Feature: Test that WP_PLUGIN_CHECK_BOOTSTRAP_FILE is loaded in the WP-CLI path.
+
+  Scenario: Bootstrap file is required when the constant points to an existing file
+    Given a WP install with the Plugin Check plugin
+    And a wp-content/pcp-bootstrap.php file:
+      """
+      <?php
+      WP_CLI::log( 'PCP bootstrap loaded' );
+      """
+    And a wp-content/pcp-config.php file:
+      """
+      <?php
+      define( 'WP_PLUGIN_CHECK_BOOTSTRAP_FILE', __DIR__ . '/pcp-bootstrap.php' );
+      """
+
+    When I run the WP-CLI command `plugin list --require=./wp-content/pcp-config.php --require=./wp-content/plugins/plugin-check/cli.php`
+    Then STDOUT should contain:
+      """
+      PCP bootstrap loaded
+      """
+
+  Scenario: Missing bootstrap file surfaces a warning and does not halt execution
+    Given a WP install with the Plugin Check plugin
+    And a wp-content/pcp-config.php file:
+      """
+      <?php
+      define( 'WP_PLUGIN_CHECK_BOOTSTRAP_FILE', __DIR__ . '/pcp-bootstrap-missing.php' );
+      """
+
+    When I run the WP-CLI command `plugin list --require=./wp-content/pcp-config.php --require=./wp-content/plugins/plugin-check/cli.php`
+    Then STDERR should contain:
+      """
+      WP_PLUGIN_CHECK_BOOTSTRAP_FILE
+      """
+    And STDERR should contain:
+      """
+      but the file does not exist
+      """
+
+  Scenario: Undefined constant is a no-op
+    Given a WP install with the Plugin Check plugin
+
+    When I run the WP-CLI command `plugin list --require=./wp-content/plugins/plugin-check/cli.php`
+    Then STDERR should not contain:
+      """
+      WP_PLUGIN_CHECK_BOOTSTRAP_FILE
+      """

--- a/tests/behat/features/plugin-check-bootstrap-file.feature
+++ b/tests/behat/features/plugin-check-bootstrap-file.feature
@@ -45,3 +45,59 @@ Feature: Test that WP_PLUGIN_CHECK_BOOTSTRAP_FILE is loaded in the WP-CLI path.
       """
       WP_PLUGIN_CHECK_BOOTSTRAP_FILE
       """
+
+  Scenario: Bootstrap file can register listeners that fire on setup/cleanup hooks
+    Given a WP install with the Plugin Check plugin
+    And a wp-content/plugins/foo-single.php file:
+      """
+      <?php
+      /**
+       * Plugin Name: Foo Single
+       * Plugin URI: https://foo-single.com
+       * Description: Custom plugin.
+       * Version: 0.1.0
+       * Author: WordPress Performance Team
+       * Author URI: https://make.wordpress.org/performance/
+       * License: GPL-2.0+
+       * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
+       */
+
+      add_action(
+        'init',
+        function () {
+          $number = mt_rand( 10, 100 );
+          echo $number;
+        }
+      );
+      """
+    And a wp-content/pcp-bootstrap.php file:
+      """
+      <?php
+      add_action(
+          'wp_plugin_check_before_setup_environment',
+          static function () {
+              WP_CLI::log( 'PCP before_setup fired' );
+          }
+      );
+      add_action(
+          'wp_plugin_check_after_cleanup_environment',
+          static function () {
+              WP_CLI::log( 'PCP after_cleanup fired' );
+          }
+      );
+      """
+    And a wp-content/pcp-config.php file:
+      """
+      <?php
+      define( 'WP_PLUGIN_CHECK_BOOTSTRAP_FILE', __DIR__ . '/pcp-bootstrap.php' );
+      """
+
+    When I run the WP-CLI command `plugin check foo-single.php --require=./wp-content/pcp-config.php --require=./wp-content/plugins/plugin-check/cli.php`
+    Then STDOUT should contain:
+      """
+      PCP before_setup fired
+      """
+    And STDOUT should contain:
+      """
+      PCP after_cleanup fired
+      """

--- a/tests/phpunit/tests/Checker/Runtime_Environment_Setup_Tests.php
+++ b/tests/phpunit/tests/Checker/Runtime_Environment_Setup_Tests.php
@@ -166,4 +166,41 @@ class Runtime_Environment_Setup_Tests extends WP_UnitTestCase {
 		$this->assertTrue( 0 <= strpos( $wpdb->last_query, $table_prefix . 'pc_' ) );
 		$this->assertFalse( $wp_filesystem->exists( WP_CONTENT_DIR . '/object-cache.php' ) );
 	}
+
+	/**
+	 * Ensures the after_setup_environment action fires when set_up() returns early.
+	 *
+	 * This test relies on the drop-in version constant being defined at this point in the run.
+	 * `test_clean_up` defines it earlier in the same process, so set_up() takes the early-return
+	 * branch guarded by `WP_PLUGIN_CHECK_OBJECT_CACHE_DROPIN_VERSION`. The after_* action lives
+	 * in a `finally` block and must still fire.
+	 */
+	public function test_set_up_fires_after_action_on_early_return() {
+		$this->set_up_mock_filesystem();
+
+		if ( ! defined( 'WP_PLUGIN_CHECK_OBJECT_CACHE_DROPIN_VERSION' ) ) {
+			define( 'WP_PLUGIN_CHECK_OBJECT_CACHE_DROPIN_VERSION', 1 );
+		}
+
+		$this->assertTrue(
+			defined( 'WP_PLUGIN_CHECK_OBJECT_CACHE_DROPIN_VERSION' ) && WP_PLUGIN_CHECK_OBJECT_CACHE_DROPIN_VERSION,
+			'Pre-condition: the drop-in version constant must be defined to force the early-return branch.'
+		);
+
+		$after_called = false;
+		add_action(
+			'wp_plugin_check_after_setup_environment',
+			static function () use ( &$after_called ) {
+				$after_called = true;
+			}
+		);
+
+		$runtime_setup = new Runtime_Environment_Setup();
+		$runtime_setup->set_up();
+
+		$this->assertTrue(
+			$after_called,
+			'wp_plugin_check_after_setup_environment must fire even when set_up() returns early.'
+		);
+	}
 }

--- a/tests/phpunit/tests/Checker/Runtime_Environment_Setup_Tests.php
+++ b/tests/phpunit/tests/Checker/Runtime_Environment_Setup_Tests.php
@@ -92,6 +92,64 @@ class Runtime_Environment_Setup_Tests extends WP_UnitTestCase {
 		$this->assertFalse( $runtime_setup->can_set_up() );
 	}
 
+	public function test_set_up_fires_setup_environment_hooks() {
+		$this->set_up_mock_filesystem();
+
+		$calls = array();
+
+		add_action(
+			'wp_plugin_check_before_setup_environment',
+			static function ( $environment_setup ) use ( &$calls ) {
+				$calls[] = array( 'before', $environment_setup );
+			}
+		);
+
+		add_action(
+			'wp_plugin_check_after_setup_environment',
+			static function ( $environment_setup ) use ( &$calls ) {
+				$calls[] = array( 'after', $environment_setup );
+			}
+		);
+
+		$runtime_setup = new Runtime_Environment_Setup();
+		$runtime_setup->set_up();
+
+		$this->assertCount( 2, $calls );
+		$this->assertSame( 'before', $calls[0][0] );
+		$this->assertSame( 'after', $calls[1][0] );
+		$this->assertSame( $runtime_setup, $calls[0][1] );
+		$this->assertSame( $runtime_setup, $calls[1][1] );
+	}
+
+	public function test_clean_up_fires_cleanup_environment_hooks() {
+		$this->set_up_mock_filesystem();
+
+		$calls = array();
+
+		add_action(
+			'wp_plugin_check_before_cleanup_environment',
+			static function ( $environment_setup ) use ( &$calls ) {
+				$calls[] = array( 'before', $environment_setup );
+			}
+		);
+
+		add_action(
+			'wp_plugin_check_after_cleanup_environment',
+			static function ( $environment_setup ) use ( &$calls ) {
+				$calls[] = array( 'after', $environment_setup );
+			}
+		);
+
+		$runtime_setup = new Runtime_Environment_Setup();
+		$runtime_setup->clean_up();
+
+		$this->assertCount( 2, $calls );
+		$this->assertSame( 'before', $calls[0][0] );
+		$this->assertSame( 'after', $calls[1][0] );
+		$this->assertSame( $runtime_setup, $calls[0][1] );
+		$this->assertSame( $runtime_setup, $calls[1][1] );
+	}
+
 	public function test_clean_up() {
 		global $wp_filesystem, $wpdb, $table_prefix;
 


### PR DESCRIPTION
## Summary

Adds the four lifecycle actions proposed in #1269 around `Runtime_Environment_Setup::set_up()` / `clean_up()`, plus a `WP_PLUGIN_CHECK_BOOTSTRAP_FILE` constant that lets integrations register listeners early enough to actually subscribe to those actions on both admin and WP-CLI paths.

**Scope note vs. #1269.** The original issue only asks for the four actions. In practice, hooks without an early-enough subscription point are unusable for the main consumer use case: the runtime-check environment is configured before plugins/mu-plugins load, so there is no place for an integration to register listeners. This PR therefore adds both pieces together. If the maintainers would rather review them separately, happy to split into two PRs on request.

### Actions

Four new actions, each receiving the `Runtime_Environment_Setup` instance:

- `wp_plugin_check_before_setup_environment`
- `wp_plugin_check_after_setup_environment`
- `wp_plugin_check_before_cleanup_environment`
- `wp_plugin_check_after_cleanup_environment`

`set_up()` and `clean_up()` both have early-return paths inside their bodies. The implementation wraps each body in `try { … } finally { do_action( 'wp_plugin_check_after_*' ) }` so the after_* action fires whenever the body is entered, including on early `return`. The before_* action is dispatched outside the `try` — if a `before_*` subscriber throws, no `after_*` will fire, which keeps the pair semantics consistent (no "after" for a setup that never started).

### Bootstrap file

New constant `WP_PLUGIN_CHECK_BOOTSTRAP_FILE` holds an absolute path to a PHP file. PCP `require_once`s it on its two earliest entry points, *after* the autoloader is in place but *before* the runner is initialised / the CLI command is registered:

- `drop-ins/object-cache.copy.php` — inside `plugin_check_initialize_runner()`, before `Plugin_Request_Utility::initialize_runner()`.
- `cli.php` — after the autoloader load, before `WP_CLI::add_command()`.

Because the bootstrap-loading block lives inside `drop-ins/object-cache.copy.php`, it is automatically present in the auto-generated `wp-content/object-cache.php` — no extra injection step, no template variable. The drop-in's existing byte-comparison cleanup still works since the source and the generated copy stay in sync.

Error handling:

| Constant state | Behaviour |
|---|---|
| Undefined | No-op. |
| Defined, empty / non-string | No-op. |
| Defined, file exists | `require_once`. |
| Defined, file missing | Warning, execution continues (`WP_CLI::warning()` in CLI, `E_USER_WARNING` in the drop-in). |

The constant is expected to be set in `wp-config.php`, which the site owner controls — no path-prefix validation is performed, mirroring how WP treats other path constants set there.

### Why both, atomically

The same integration that wants to subscribe to setup/cleanup actions also needs the bootstrap file in order to subscribe early enough. Shipping the actions without an early-enough hook point would leave the headline use case from #1269 unsolved.

### Out of scope (separate PRs)

The brief that motivated this PR also flagged two further extension points; intentionally left out to keep this PR atomic:

- `wp_plugin_check_check_args` filter on `get_args()` of Check classes.
- A WP-CLI `--config` flag.

## Test plan

- [x] PHPUnit: two new tests in `Runtime_Environment_Setup_Tests` verifying that each action pair fires and is passed the setup instance, plus `test_set_up_fires_after_action_on_early_return` pinning the early-return guarantee.
- [x] Behat: `tests/behat/features/plugin-check-bootstrap-file.feature` — bootstrap file is required when present, missing file surfaces a warning without halting, undefined constant is a no-op, and a bootstrap-registered listener on a setup/cleanup action actually fires during a real `plugin check` run.
- [x] `phpcs --standard=phpcs.xml.dist` clean on touched files.
- [ ] Run the full PHPUnit and Behat suites in CI.

Refs #1269.