### PR TITLE
Fix Playground PR previews for forked pull requests

### DIFF
--- a/.github/workflows/pr-playground-preview-publish.yml
+++ b/.github/workflows/pr-playground-preview-publish.yml
@@ -1,0 +1,108 @@
+name: PR Playground Preview Publish
+
+# Publishes the read-only build artifact from "PR Playground Preview Build" and
+# writes the Playground button to the PR. This workflow must not check out or
+# execute pull request code.
+
+on:
+  workflow_run:
+    workflows:
+      - PR Playground Preview Build
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: write
+  pull-requests: write
+
+jobs:
+  playground-preview:
+    name: Publish Playground preview button
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Download Playground preview metadata
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          gh run download "$RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name plugin-check-preview-metadata \
+            --dir preview-metadata
+
+      - name: Read Playground preview metadata
+        id: metadata
+        run: |
+          pr_number="$(cat preview-metadata/pr-number)"
+          head_sha="$(cat preview-metadata/head-sha)"
+
+          if ! [[ "$pr_number" =~ ^[0-9]+$ ]]; then
+            echo "Invalid PR number in preview metadata: $pr_number" >&2
+            exit 1
+          fi
+
+          if ! [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Invalid head SHA in preview metadata: $head_sha" >&2
+            exit 1
+          fi
+
+          echo "pr-number=$pr_number" >> "$GITHUB_OUTPUT"
+          echo "head-sha=$head_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Expose built artifact as a public URL
+        id: expose
+        uses: WordPress/action-wp-playground-pr-preview/.github/actions/expose-artifact-on-public-url@v2
+        with:
+          artifact-name:              plugin-check-zip
+          artifact-filename:          plugin-check.zip
+          artifact-source-run-id:     ${{ github.event.workflow_run.id }}
+          artifact-source-repository: ${{ github.repository }}
+          pr-number:                  ${{ steps.metadata.outputs.pr-number }}
+          commit-sha:                 ${{ steps.metadata.outputs.head-sha }}
+          artifacts-to-keep:          '2'
+          github-token:               ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate Playground blueprint
+        id: blueprint
+        env:
+          ARTIFACT_URL: ${{ steps.expose.outputs.artifact-url }}
+        run: |
+          node - <<'NODE' >> "$GITHUB_OUTPUT"
+          const url = process.env.ARTIFACT_URL;
+          if (!url) {
+            throw new Error('ARTIFACT_URL is required');
+          }
+          const blueprint = {
+            "$schema": "https://playground.wordpress.net/blueprint-schema.json",
+            landingPage: "/wp-admin/tools.php?page=plugin-check",
+            phpExtensionBundles: [ "kitchen-sink" ],
+            steps: [
+              {
+                step: "login",
+                username: "admin",
+                password: "password",
+              },
+              {
+                step: "installPlugin",
+                pluginZipFile: {
+                  resource: "url",
+                  url,
+                },
+                options: { activate: true },
+              },
+            ],
+          };
+          console.log(`blueprint=${JSON.stringify(blueprint)}`);
+          NODE
+
+      - name: Post Playground Preview Button
+        uses: WordPress/action-wp-playground-pr-preview@v2
+        with:
+          mode:         append-to-description
+          blueprint:    ${{ steps.blueprint.outputs.blueprint }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number:    ${{ steps.metadata.outputs.pr-number }}

--- a/.github/workflows/pr-playground-preview-publish.yml
+++ b/.github/workflows/pr-playground-preview-publish.yml
@@ -7,6 +7,7 @@ name: PR Playground Preview Publish
 on:
   workflow_run:
     workflows:
+      - PR Playground Preview
       - PR Playground Preview Build
     types:
       - completed

--- a/.github/workflows/pr-playground-preview.yml
+++ b/.github/workflows/pr-playground-preview.yml
@@ -1,24 +1,13 @@
-name: PR Playground Preview
+name: PR Playground Preview Build
 
-# Adds an official "Open in WordPress Playground" button to every pull request
-# so reviewers can boot this PR's build of Plugin Check in their browser with
-# a single click.
-#
-# How it works:
-# 1. Install Plugin Check's Composer dependencies (without --dev), so the
-#    resulting tree contains the vendor/autoload.php the plugin requires.
-# 2. Build a production zip honouring the existing .distignore.
-# 3. Upload the zip as a workflow artifact.
-# 4. Expose the artifact on a public download URL via the
-#    WordPress/action-wp-playground-pr-preview helper.
-# 5. Generate a blueprint that installs the plugin from that URL and lands on
-#    Tools → Plugin Check.
-# 6. Append the official "Open in WordPress Playground" button to the PR
-#    description.
+# Builds a Plugin Check zip for every pull request. A separate workflow_run
+# publisher exposes the artifact and posts the Playground preview button, so
+# forked PRs can be supported without running untrusted PR code with write
+# permissions.
 #
 # References:
 # - https://github.com/WordPress/action-wp-playground-pr-preview/tree/v2
-# - https://github.com/adamziel/preview-in-playground-button-plugin-example/pull/3
+# - https://wordpress.github.io/wordpress-playground/guides/github-action-pr-preview/
 
 on:
   pull_request:
@@ -29,12 +18,11 @@ on:
       - edited
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
-  playground-preview:
-    name: Build and post Playground preview button
+  build:
+    name: Build Playground preview artifact
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR head
@@ -65,60 +53,24 @@ jobs:
           zip -qr "${PLUGIN_SLUG}.zip" "${PLUGIN_SLUG}"
           ls -lh "${PLUGIN_SLUG}.zip"
 
+      - name: Write Playground preview metadata
+        run: |
+          mkdir -p build/playground-preview
+          printf '%s' '${{ github.event.pull_request.number }}' > build/playground-preview/pr-number
+          printf '%s' '${{ github.event.pull_request.head.sha }}' > build/playground-preview/head-sha
+
       - name: Upload plugin zip artifact
         uses: actions/upload-artifact@v7
         with:
-          name: plugin-check-zip-pr${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+          name: plugin-check-zip
           path: build/plugin-check.zip
           if-no-files-found: error
           retention-days: 5
 
-      - name: Expose built artifact as a public URL
-        id: expose
-        uses: WordPress/action-wp-playground-pr-preview/.github/actions/expose-artifact-on-public-url@v2
+      - name: Upload Playground preview metadata
+        uses: actions/upload-artifact@v7
         with:
-          artifact-name:     plugin-check-zip-pr${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
-          artifact-filename: plugin-check.zip
-          pr-number:         ${{ github.event.pull_request.number }}
-          commit-sha:        ${{ github.event.pull_request.head.sha }}
-          artifacts-to-keep: '2'
-
-      - name: Generate Playground blueprint
-        id: blueprint
-        env:
-          ARTIFACT_URL: ${{ steps.expose.outputs.artifact-url }}
-        run: |
-          node - <<'NODE' >> "$GITHUB_OUTPUT"
-          const url = process.env.ARTIFACT_URL;
-          if (!url) {
-            throw new Error('ARTIFACT_URL is required');
-          }
-          const blueprint = {
-            "$schema": "https://playground.wordpress.net/blueprint-schema.json",
-            landingPage: "/wp-admin/tools.php?page=plugin-check",
-            phpExtensionBundles: [ "kitchen-sink" ],
-            steps: [
-              {
-                step: "login",
-                username: "admin",
-                password: "password",
-              },
-              {
-                step: "installPlugin",
-                pluginZipFile: {
-                  resource: "url",
-                  url,
-                },
-                options: { activate: true },
-              },
-            ],
-          };
-          console.log(`blueprint=${JSON.stringify(blueprint)}`);
-          NODE
-
-      - name: Post Playground Preview Button
-        uses: WordPress/action-wp-playground-pr-preview@v2
-        with:
-          mode:         append-to-description
-          blueprint:    ${{ steps.blueprint.outputs.blueprint }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          name: plugin-check-preview-metadata
+          path: build/playground-preview
+          if-no-files-found: error
+          retention-days: 5

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Every pull request opened against this repository gets an automatic **"Open in W
 
 The preview boots a fresh WordPress, installs and activates the PR's build of Plugin Check, logs you in as `admin` / `password`, and lands on _Tools → Plugin Check_ so you can run a check straight away. This makes reviewing UI, admin behaviour, and check output dramatically faster, and lowers the bar for non-developer reviewers.
 
-The button is added by the official [`WordPress/action-wp-playground-pr-preview`](https://github.com/WordPress/action-wp-playground-pr-preview) action via `.github/workflows/pr-playground-preview.yml`. That workflow builds a production zip of the plugin (Composer dependencies installed without `--dev`, dev files excluded via `.distignore`), uploads it as a GitHub Actions artifact, exposes it on a public download URL, and appends the **"Open in WordPress Playground"** button to the PR description with a blueprint that installs and activates that exact build.
+The button is added by the official [`WordPress/action-wp-playground-pr-preview`](https://github.com/WordPress/action-wp-playground-pr-preview) action via `.github/workflows/pr-playground-preview.yml` and `.github/workflows/pr-playground-preview-publish.yml`. The first workflow builds a production zip of the plugin (Composer dependencies installed without `--dev`, dev files excluded via `.distignore`) with read-only permissions and uploads it as a GitHub Actions artifact. After that build succeeds, the publisher workflow exposes the artifact on a public download URL and appends the **"Open in WordPress Playground"** button to the PR description with a blueprint that installs and activates that exact build.
 
 ## Contributing
 


### PR DESCRIPTION
## What?
Fixes the Playground PR preview workflow so it can publish preview buttons for pull requests opened from forks.

## Why?

The previous workflow built the Plugin Check zip and posted the Playground button from the same `pull_request` workflow. That works for repo members, but forked PRs receive a read-only `GITHUB_TOKEN`, so the action cannot update the PR description.

## How?

Splits the Playground preview process into two workflows:

- `PR Playground Preview Build` runs on `pull_request` with read-only permissions, builds the plugin zip, and uploads the zip plus PR metadata as artifacts.
- `PR Playground Preview Publish` runs on `workflow_run` after a successful build, exposes the built zip on the public `ci-artifacts` release, generates the Playground blueprint, and posts the preview button to the PR.

The publisher workflow does not check out or execute PR code, keeping write permissions separate from untrusted fork code.

## Testing Instructions

1. Open a pull request from a fork.
2. Wait for `PR Playground Preview Build` to complete successfully.
3. Confirm `PR Playground Preview Publish` runs after the build.
4. Confirm the PR description includes the **Open in WordPress Playground** button.
5. Click the button and verify Playground opens with Plugin Check installed and activated.
6. Confirm it lands on _Tools > Plugin Check_.

## AI Usage Disclosure

- [x] This PR includes AI-assisted code or content

If AI tools were used, please describe how they were used:
Used ChatGPT/Codex to investigate the GitHub Actions permission issue and draft the workflow changes.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|Forked PRs could fail with `Resource not accessible by integration` when trying to update the PR description.|Forked PRs build with read-only permissions, then a separate publisher workflow posts the Playground preview button.|