### PR TITLE
Prepare release 2.0.0

### DIFF
--- a/docs/checks.md
+++ b/docs/checks.md
@@ -28,6 +28,7 @@
 | no_unfiltered_uploads | plugin_repo | Detects disallowed usage of <code>ALLOW_UNFILTERED_UPLOADS</code>. | [Learn more](https://make.wordpress.org/plugins/handbook/performing-reviews/review-checklist/) |
 | trademarks | plugin_repo | Checks the usage of trademarks or other projects in the plugin slug. | [Learn more](https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/) |
 | offloading_files | plugin_repo | Prevents using remote services that are not necessary. | [Learn more](https://developer.wordpress.org/plugins/wordpress-org/common-issues/#calling-files-remotely) |
+| write_file | plugin_repo | Detects if plugins save data in the plugin folder instead of using the uploads directory or database. | [Learn more](https://developer.wordpress.org/plugins/wordpress-org/common-issues/#saving-data-in-the-plugin-folder) |
 | setting_sanitization | plugin_repo | Ensures sanitization in register_setting(). | [Learn more](https://developer.wordpress.org/reference/functions/register_setting/) |
 | prefixing | plugin_repo | Checks plugin for unique prefixing for everything the plugin defines in the public namespace. | [Learn more](https://developer.wordpress.org/plugins/plugin-basics/best-practices/) |
 | enqueued_scripts_size | performance | Checks whether the cumulative size of all scripts enqueued on a page exceeds 293 KB. | [Learn more](https://developer.wordpress.org/plugins/) |

--- a/plugin.php
+++ b/plugin.php
@@ -5,7 +5,7 @@
  * Description: Plugin Check is a WordPress.org tool which provides checks to help plugins meet the directory requirements and follow various best practices.
  * Requires at least: 6.3
  * Requires PHP: 7.4
- * Version: 1.9.0
+ * Version: 2.0.0
  * Author: WordPress Performance Team and Plugins Team
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
@@ -16,7 +16,7 @@
 
 use WordPress\Plugin_Check\Plugin_Main;
 
-define( 'WP_PLUGIN_CHECK_VERSION', '1.9.0' );
+define( 'WP_PLUGIN_CHECK_VERSION', '2.0.0' );
 define( 'WP_PLUGIN_CHECK_MINIMUM_PHP', '7.4' );
 define( 'WP_PLUGIN_CHECK_MAIN_FILE', __FILE__ );
 define( 'WP_PLUGIN_CHECK_PLUGIN_DIR_PATH', plugin_dir_path( WP_PLUGIN_CHECK_MAIN_FILE ) );

--- a/readme.txt
+++ b/readme.txt
@@ -93,13 +93,19 @@ In any case, passing the checks in this tool likely helps to achieve a smooth pl
 * Enhancement - Add CTRF export support for check results.
 * Enhancement - Add an error count summary to the Plugin Check UI.
 * Enhancement - Improve Direct File Access detection for library-style files.
+* Enhancement - Adjust checks for update mode.
 * Fix - Relax Update URI header validation for WordPress.org plugin URLs.
 * Fix - Improve WordPress functions compatibility detection to avoid PHP serialization false positives.
 * Fix - Respect `wp_supports_ai()` and text-capable model filtering in the Plugin Namer.
 * Fix - Show Plugin Namer token usage in results.
 * Fix - Recognize EUPL as a GPL-compatible license.
+* Fix - Improve internationalization for emoji-prefixed labels.
+* Fix - Update PHPCS sniffer repository links.
 * Tweak - Update WP-CLI runtime checks documentation.
 * Chore - Add automated WordPress function compatibility data generation.
+* Chore - Add AI usage disclosure to the pull request template.
+* Chore - Add AI coding agent instructions.
+* Chore - Clean up wp-env development and test configuration warnings.
 * Chore - Show a WordPress Playground preview button on pull requests.
 * Chore - Update development and CI dependencies.
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors:      wordpressdotorg
 Tested up to:      7.0
-Stable tag:        1.9.0
+Stable tag:        2.0.0
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              plugin best practices, testing, accessibility, performance, security
@@ -40,6 +40,10 @@ Plugin Check now includes an AI-powered Plugin Namer tool (accessible via _Tools
 The Plugin Namer provides instant feedback with actionable suggestions, helping you choose a clear, unique, and policy-compliant name that stands out in the plugin directory. This feature requires WordPress 7.0+ and configured AI connectors.
 
 **Important:** The Plugin Namer tool provides guidance only and is not definitive. All plugin name decisions are subject to final review and approval by the WordPress.org Plugins team reviewers.
+
+= Checks reviewed by AI =
+
+When AI analysis is enabled, Plugin Check can review selected results to help identify likely false positives. Related issues are grouped and analyzed with prompts tailored to the type of check, using the surrounding code as context. The AI review does not remove or change the original results, but adds an additional summary that highlights which findings may need human review before taking action.
 
 == Installation ==
 
@@ -80,6 +84,24 @@ To be approved in the WordPress.org plugin directory, a plugin must typically pa
 In any case, passing the checks in this tool likely helps to achieve a smooth plugin review process, but is no guarantee that a plugin will be approved in the WordPress.org plugin directory.
 
 == Changelog ==
+
+= 2.0.0 =
+
+* Enhancement - Add WordPress functions compatibility check to flag usage of functions unavailable in a plugin's declared minimum WordPress version.
+* Enhancement - Add Write File check to detect plugins saving data in the plugin folder instead of the uploads directory or database.
+* Enhancement - Add batched AI false positive detection with check-specific prompts and AI model selection for WP-CLI.
+* Enhancement - Add CTRF export support for check results.
+* Enhancement - Add an error count summary to the Plugin Check UI.
+* Enhancement - Improve Direct File Access detection for library-style files.
+* Fix - Relax Update URI header validation for WordPress.org plugin URLs.
+* Fix - Improve WordPress functions compatibility detection to avoid PHP serialization false positives.
+* Fix - Respect `wp_supports_ai()` and text-capable model filtering in the Plugin Namer.
+* Fix - Show Plugin Namer token usage in results.
+* Fix - Recognize EUPL as a GPL-compatible license.
+* Tweak - Update WP-CLI runtime checks documentation.
+* Chore - Add automated WordPress function compatibility data generation.
+* Chore - Show a WordPress Playground preview button on pull requests.
+* Chore - Update development and CI dependencies.
 
 = 1.9.0 =
 


### PR DESCRIPTION
## Summary

Prepares Plugin Check for the 2.0.0 release.

## Changes

- Bumps the plugin header `Version` to `2.0.0`.
- Bumps `WP_PLUGIN_CHECK_VERSION` to `2.0.0`.
- Updates the `Stable tag` in `readme.txt` to `2.0.0`.
- Adds the `2.0.0` changelog entry.
- Adds the “Checks reviewed by AI” section to the readme.
- Updates `docs/checks.md` with the `write_file` check.

## Notes

The changelog was reviewed against PRs merged after `1.9.0`, and includes the expected #1278 changes for the 2.0.0 release.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Ftools.php%3Fpage%3Dplugin-check%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fplugin-check%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1331-bad8dd0d36683798d6dcee836d53195ba30c79a9.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->