### PR TITLE
Add multisite (Network Admin) support for the admin page

### DIFF
--- a/includes/Admin/Admin_Page.php
+++ b/includes/Admin/Admin_Page.php
@@ -56,7 +56,9 @@ final class Admin_Page {
 	 */
 	public function add_hooks() {
 		add_action( 'admin_menu', array( $this, 'add_and_initialize_page' ) );
+		add_action( 'network_admin_menu', array( $this, 'add_and_initialize_network_page' ) );
 		add_filter( 'plugin_action_links', array( $this, 'filter_plugin_action_links' ), 10, 4 );
+		add_filter( 'network_admin_plugin_action_links', array( $this, 'filter_network_admin_plugin_action_links' ), 10, 4 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'add_jump_to_line_code_editor' ) );
 
 		$this->admin_ajax->add_hooks();
@@ -84,6 +86,35 @@ final class Admin_Page {
 	 */
 	public function add_and_initialize_page() {
 		$this->add_page();
+		add_action( 'load-' . $this->get_hook_suffix(), array( $this, 'initialize_page' ) );
+	}
+
+	/**
+	 * Adds the admin page under the network "Settings" menu.
+	 *
+	 * The "Tools" menu does not exist in the Network Admin, so the screen is
+	 * added under "Settings" (settings.php) instead.
+	 *
+	 * @since 2.1.0
+	 */
+	public function add_network_page() {
+		$this->hook_suffix = add_submenu_page(
+			'settings.php',
+			__( 'Plugin Check', 'plugin-check' ),
+			__( 'Plugin Check', 'plugin-check' ),
+			'manage_network_plugins',
+			'plugin-check',
+			array( $this, 'render_page' )
+		);
+	}
+
+	/**
+	 * Adds and initializes the admin page under the network "Settings" menu.
+	 *
+	 * @since 2.1.0
+	 */
+	public function add_and_initialize_network_page() {
+		$this->add_network_page();
 		add_action( 'load-' . $this->get_hook_suffix(), array( $this, 'initialize_page' ) );
 	}
 
@@ -336,6 +367,39 @@ final class Admin_Page {
 	 * @return array The modified list of actions.
 	 */
 	public function filter_plugin_action_links( $actions, $plugin_file, $plugin_data, $context ) {
+		return $this->add_check_action_link( $actions, $plugin_file, $context, admin_url( 'tools.php?page=plugin-check' ) );
+	}
+
+	/**
+	 * Adds "check this plugin" link in the Network Admin plugins list table.
+	 *
+	 * In the Network Admin the page lives under "Settings" (settings.php), so
+	 * the link URL differs from the regular WP Admin.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param array  $actions     List of actions.
+	 * @param string $plugin_file Plugin main file.
+	 * @param array  $plugin_data An array of plugin data.
+	 * @param string $context     The plugin context.
+	 * @return array The modified list of actions.
+	 */
+	public function filter_network_admin_plugin_action_links( $actions, $plugin_file, $plugin_data, $context ) {
+		return $this->add_check_action_link( $actions, $plugin_file, $context, network_admin_url( 'settings.php?page=plugin-check' ) );
+	}
+
+	/**
+	 * Adds the "check this plugin" action link using the given page URL.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param array  $actions     List of actions.
+	 * @param string $plugin_file Plugin main file.
+	 * @param string $context     The plugin context.
+	 * @param string $page_url    The Plugin Check page URL to link to.
+	 * @return array The modified list of actions.
+	 */
+	private function add_check_action_link( $actions, $plugin_file, $context, $page_url ) {
 
 		if ( in_array( $context, array( 'mustuse', 'dropins' ), true ) ) {
 			return $actions;
@@ -345,7 +409,7 @@ final class Admin_Page {
 		if ( $plugin_check_base_name === $plugin_file ) {
 			$actions[] = sprintf(
 				'<a href="%1$s">%2$s</a>',
-				esc_url( admin_url( 'tools.php?page=plugin-check' ) ),
+				esc_url( $page_url ),
 				esc_html__( 'Check a plugin', 'plugin-check' )
 			);
 			return $actions;
@@ -354,7 +418,7 @@ final class Admin_Page {
 		if ( current_user_can( 'activate_plugins' ) ) {
 			$actions[] = sprintf(
 				'<a href="%1$s">%2$s</a>',
-				esc_url( admin_url( "tools.php?page=plugin-check&plugin={$plugin_file}" ) ),
+				esc_url( $page_url . "&plugin={$plugin_file}" ),
 				esc_html__( 'Check this plugin', 'plugin-check' )
 			);
 		}

--- a/tests/phpunit/tests/Admin/Admin_Page_Tests.php
+++ b/tests/phpunit/tests/Admin/Admin_Page_Tests.php
@@ -25,7 +25,39 @@ class Admin_Page_Tests extends WP_UnitTestCase {
 	public function test_add_hooks() {
 		$this->admin_page->add_hooks();
 		$this->assertEquals( 10, has_action( 'admin_menu', array( $this->admin_page, 'add_and_initialize_page' ) ) );
+		$this->assertEquals( 10, has_action( 'network_admin_menu', array( $this->admin_page, 'add_and_initialize_network_page' ) ) );
 		$this->assertEquals( 10, has_filter( 'plugin_action_links', array( $this->admin_page, 'filter_plugin_action_links' ) ) );
+		$this->assertEquals( 10, has_filter( 'network_admin_plugin_action_links', array( $this->admin_page, 'filter_network_admin_plugin_action_links' ) ) );
+	}
+
+	public function test_add_and_initialize_network_page() {
+
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'The Network Admin is only available on multisite.' );
+		}
+
+		global $_parent_pages;
+
+		$current_screen = get_current_screen();
+
+		$admin_user = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		grant_super_admin( $admin_user );
+		wp_set_current_user( $admin_user );
+
+		set_current_screen( 'dashboard-network' );
+
+		$this->admin_page->add_and_initialize_network_page();
+		$page_hook    = $this->admin_page->get_hook_suffix();
+		$parent_pages = $_parent_pages;
+
+		set_current_screen( $current_screen );
+
+		$this->assertNotEmpty( $page_hook );
+
+		// In the Network Admin the page lives under "Settings" (settings.php).
+		$this->assertArrayHasKey( 'plugin-check', $parent_pages );
+		$this->assertEquals( 'settings.php', $parent_pages['plugin-check'] );
+		$this->assertNotFalse( has_action( "load-{$page_hook}", array( $this->admin_page, 'initialize_page' ) ) );
 	}
 
 	public function test_add_and_initialize_page() {
@@ -150,6 +182,33 @@ class Admin_Page_Tests extends WP_UnitTestCase {
 			sprintf(
 				'<a href="%1$s">%2$s</a>',
 				esc_url( admin_url( "tools.php?page=plugin-check&plugin={$base_file}" ) ),
+				esc_html__( 'Check this plugin', 'plugin-check' )
+			),
+			$action_links[0]
+		);
+	}
+
+	public function test_filter_network_admin_plugin_action_links() {
+
+		$base_file = 'akismet/akismet.php';
+
+		$action_links = $this->admin_page->filter_network_admin_plugin_action_links( array(), $base_file, array(), 'all' );
+		$this->assertEmpty( $action_links );
+
+		/** Administrator check */
+		$admin_user = self::factory()->user->create( array( 'role' => 'administrator' ) );
+
+		if ( is_multisite() ) {
+			grant_super_admin( $admin_user );
+		}
+		wp_set_current_user( $admin_user );
+		$action_links = $this->admin_page->filter_network_admin_plugin_action_links( array(), $base_file, array(), 'all' );
+
+		// In the Network Admin the link points to settings.php instead of tools.php.
+		$this->assertEquals(
+			sprintf(
+				'<a href="%1$s">%2$s</a>',
+				esc_url( network_admin_url( "settings.php?page=plugin-check&plugin={$base_file}" ) ),
 				esc_html__( 'Check this plugin', 'plugin-check' )
 			),
 			$action_links[0]


### PR DESCRIPTION
## Summary

Fixes #64.

The admin screen and the plugin action link were limited to the individual site's WP Admin. This expands both to also work in the **Network Admin**, which is important because on some multisite configurations regular administrators are not allowed to control plugins.

## Changes

**`includes/Admin/Admin_Page.php`**
- `add_hooks()` now also registers:
  - `network_admin_menu` → `add_and_initialize_network_page`
  - the `network_admin_plugin_action_links` filter → `filter_network_admin_plugin_action_links`
- New `add_network_page()` / `add_and_initialize_network_page()` — registers the screen under **Settings** (`settings.php`) via `add_submenu_page()` with the `manage_network_plugins` capability, since the "Tools" menu does not exist in the Network Admin. The screen reuses the existing `render_page` / `initialize_page` callbacks, so it behaves the same as in the regular WP Admin.
- New `filter_network_admin_plugin_action_links()` — adds the action link in the Network Admin plugins list, pointing at `network_admin_url( 'settings.php?page=plugin-check' )` (the page lives under `settings.php` here instead of `tools.php`).
- The shared link-building logic is extracted into a private `add_check_action_link()` helper; only the base page URL is parameterized, so the existing single-site URLs are unchanged.

## Test coverage

**`tests/phpunit/tests/Admin/Admin_Page_Tests.php`**
- `test_add_hooks` extended to assert the two new Network Admin hooks are registered.
- `test_add_and_initialize_network_page` — ensures the admin page is added under `settings.php` using the Network Admin specific action (skipped on non-multisite).
- `test_filter_network_admin_plugin_action_links` — ensures the plugin link is added with the `settings.php`-based URL via the Network Admin specific filter.

Verified locally on WP 7.0 across both single-site and multisite runs — `Admin_Page_Tests` passes in both (the network page test is correctly skipped on single-site and executes on multisite). PHPCS and PHPStan are clean on the changed files.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Ftools.php%3Fpage%3Dplugin-check%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fplugin-check%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1344-d3d7fab2e055e40147b116345586cc08844153ba.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->