### PR TITLE
collapse/extend results page tables

### DIFF
--- a/assets/css/plugin-check-admin.css
+++ b/assets/css/plugin-check-admin.css
@@ -179,11 +179,6 @@
 	border-bottom: 1px solid #c3c4c7;
 }
 
-.plugin-check__file-results:not(:has(.plugin-check__file-results-panel.open))
-	.plugin-check__file-results-header {
-	border-bottom: 0;
-}
-
 .plugin-check__file-results-toggle {
 	display: flex;
 	align-items: center;

--- a/assets/css/plugin-check-admin.css
+++ b/assets/css/plugin-check-admin.css
@@ -130,12 +130,128 @@
 	padding: 0 14px 14px;
 }
 
-#plugin-check__results .plugin-check__false-positive-results h4:first-child {
-	margin-top: 12px;
-}
-
 .plugin-check__false-positive-results table.plugin-check__results-table {
 	margin-bottom: 1em;
+}
+
+/* Expand/collapse: animation + layout */
+#plugin-check__results,
+.plugin-check__false-positive-results {
+	interpolate-size: allow-keywords;
+}
+
+.plugin-check__results-toolbar {
+	margin-top: 8px;
+	display: flex;
+	gap: 8px;
+	flex-wrap: wrap;
+}
+
+.plugin-check__results-toolbar.is-hidden {
+	display: none;
+}
+
+.plugin-check__toolbar-button {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	border-color: #2271b1;
+	color: #2271b1;
+	background: #fff;
+}
+
+.wp-core-ui .button.plugin-check__toolbar-button .dashicons {
+	width: 18px;
+	height: 18px;
+	font-size: 18px;
+	line-height: 0.9;
+	vertical-align: middle;
+}
+
+.plugin-check__file-results {
+	margin-bottom: 12px;
+	background: #fff;
+	border: 1px solid #c3c4c7;
+}
+
+.plugin-check__file-results-header {
+	border-left: 4px solid #2271b1;
+	border-bottom: 1px solid #c3c4c7;
+}
+
+.plugin-check__file-results:not(:has(.plugin-check__file-results-panel.open))
+	.plugin-check__file-results-header {
+	border-bottom: 0;
+}
+
+.plugin-check__file-results-toggle {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	width: 100%;
+	margin: 0;
+	padding: 12px 14px;
+	border: 0;
+	background: transparent;
+	color: #1d2327;
+	font-size: 14px;
+	font-weight: 600;
+	text-align: left;
+	cursor: pointer;
+}
+
+.plugin-check__file-results-leading {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	min-width: 0;
+}
+
+.plugin-check__file-results-toggle .dashicons {
+	flex-shrink: 0;
+	width: 20px;
+	height: 20px;
+	font-size: 20px;
+}
+
+.plugin-check__file-results-file-icon,
+.plugin-check__file-results-toggle-icon {
+	color: #2271b1;
+}
+
+.plugin-check__file-results-toggle-icon {
+	transition: transform 300ms ease;
+}
+
+.plugin-check__file-results:not(:has(.plugin-check__file-results-panel.open))
+	.plugin-check__file-results-toggle-icon {
+	transform: rotate(-90deg);
+}
+
+.plugin-check__file-results-label {
+	overflow-wrap: anywhere;
+}
+
+.plugin-check__file-results-panel {
+	height: 0;
+	overflow: hidden;
+	transition: height 300ms ease;
+}
+
+.plugin-check__file-results-panel.open {
+	height: auto;
+}
+
+.plugin-check__file-results-panel .plugin-check__results-table {
+	margin: 0;
+	border: 0;
+}
+
+@supports not (interpolate-size: allow-keywords) {
+	.plugin-check__file-results-panel {
+		transition: none;
+	}
 }
 
 .plugin-check__options {

--- a/assets/js/plugin-check-admin.js
+++ b/assets/js/plugin-check-admin.js
@@ -4,6 +4,15 @@
 	const exportContainer = document.getElementById(
 		'plugin-check__export-controls'
 	);
+	const resultsToolbar = document.getElementById(
+		'plugin-check__results-toolbar'
+	);
+	const expandAllButton = document.getElementById(
+		'plugin-check__expand-all'
+	);
+	const collapseAllButton = document.getElementById(
+		'plugin-check__collapse-all'
+	);
 	const spinner = document.getElementById( 'plugin-check__spinner' );
 	const pluginsList = document.getElementById(
 		'plugin-check__plugins-dropdown'
@@ -32,7 +41,75 @@
 	let falsePositiveResults = createEmptyAggregatedResults();
 	let checksCompleted = false;
 	exportContainer.classList.add( 'is-hidden' );
+	if ( resultsToolbar ) {
+		resultsToolbar.classList.add( 'is-hidden' );
+	}
 	exportContainer.addEventListener( 'click', onExportContainerClick );
+
+	if ( expandAllButton && collapseAllButton ) {
+		expandAllButton.addEventListener( 'click', () => {
+			setAllFileResultsExpanded( true );
+		} );
+		collapseAllButton.addEventListener( 'click', () => {
+			setAllFileResultsExpanded( false );
+		} );
+		resultsContainer.addEventListener( 'click', onFileResultsToggleClick );
+	}
+
+	/**
+	 * Sets expanded/collapsed state for one file results section.
+	 *
+	 * @param {HTMLElement} section   File results wrapper.
+	 * @param {boolean}     expanded  Whether the section is expanded.
+	 */
+	function setFileResultsExpanded( section, expanded ) {
+		const toggle = section.querySelector(
+			'.plugin-check__file-results-toggle'
+		);
+		const panel = section.querySelector( '.plugin-check__file-results-panel' );
+
+		if ( toggle ) {
+			toggle.setAttribute( 'aria-expanded', expanded ? 'true' : 'false' );
+		}
+		if ( panel ) {
+			panel.classList.toggle( 'open', expanded );
+		}
+	}
+
+	/**
+	 * Expands or collapses every file results section.
+	 *
+	 * @param {boolean} expanded Whether sections should be expanded.
+	 */
+	function setAllFileResultsExpanded( expanded ) {
+		resultsContainer
+			.querySelectorAll( '.plugin-check__file-results' )
+			.forEach( ( section ) => {
+				setFileResultsExpanded( section, expanded );
+			} );
+	}
+
+	/**
+	 * Toggles one file results section.
+	 *
+	 * @param {Event} event Click event.
+	 */
+	function onFileResultsToggleClick( event ) {
+		const toggle = event.target.closest(
+			'.plugin-check__file-results-toggle'
+		);
+		if ( ! toggle ) {
+			return;
+		}
+
+		const section = toggle.closest( '.plugin-check__file-results' );
+		if ( ! section ) {
+			return;
+		}
+
+		const isExpanded = toggle.getAttribute( 'aria-expanded' ) === 'true';
+		setFileResultsExpanded( section, ! isExpanded );
+	}
 
 	const includeExperimental = document.getElementById(
 		'plugin-check__include-experimental'
@@ -122,6 +199,9 @@
 		resultsContainer.innerText = '';
 		exportContainer.innerHTML = '';
 		exportContainer.classList.add( 'is-hidden' );
+		if ( resultsToolbar ) {
+			resultsToolbar.classList.add( 'is-hidden' );
+		}
 		resetAggregatedResults();
 		checksCompleted = false;
 	}
@@ -420,14 +500,29 @@
 		return '';
 	}
 
+	function updateResultsToolbarVisibility() {
+		if ( ! resultsToolbar ) {
+			return;
+		}
+
+		const hasFileResults = resultsContainer.querySelector(
+			'.plugin-check__file-results'
+		);
+		resultsToolbar.classList.toggle( 'is-hidden', ! hasFileResults );
+	}
+
 	function renderExportButtons() {
 		exportContainer.innerHTML = '';
 		if ( ! checksCompleted ) {
 			exportContainer.classList.add( 'is-hidden' );
+			if ( resultsToolbar ) {
+				resultsToolbar.classList.add( 'is-hidden' );
+			}
 			return;
 		}
 
 		exportContainer.classList.remove( 'is-hidden' );
+		updateResultsToolbarVisibility();
 
 		const exportButtonConfigs = [
 			{

--- a/includes/Admin/Admin_Page.php
+++ b/includes/Admin/Admin_Page.php
@@ -413,17 +413,11 @@ final class Admin_Page {
 		);
 		?>
 		<style>
-			#plugin-check__results .notice,
-			#plugin-check__results .notice + h4 {
+			#plugin-check__results .notice {
 				margin-top: 20px;
 			}
-			#plugin-check__results h4:first-child {
-				margin-top: 80.5px;
-			}
-			@media ( max-width: 782px ) {
-				#plugin-check__results h4:first-child {
-					margin-top: 88.5px;
-				}
+			#plugin-check__results .notice + .plugin-check__file-results {
+				margin-top: 12px;
 			}
 			.plugin-check__export-controls {
 				margin-top: 24px;

--- a/templates/admin-page.php
+++ b/templates/admin-page.php
@@ -104,6 +104,16 @@
 	</div>
 
 	<div id="plugin-check__export-controls" class="plugin-check__export-controls"></div>
+	<div id="plugin-check__results-toolbar" class="plugin-check__results-toolbar is-hidden" aria-label="<?php esc_attr_e( 'Results table controls', 'plugin-check' ); ?>">
+		<button type="button" id="plugin-check__collapse-all" class="button plugin-check__toolbar-button">
+			<span class="dashicons dashicons-arrow-up-alt2" aria-hidden="true"></span>
+			<?php esc_html_e( 'Collapse All', 'plugin-check' ); ?>
+		</button>
+		<button type="button" id="plugin-check__expand-all" class="button plugin-check__toolbar-button">
+			<span class="dashicons dashicons-arrow-down-alt2" aria-hidden="true"></span>
+			<?php esc_html_e( 'Expand All', 'plugin-check' ); ?>
+		</button>
+	</div>
 	<div id="plugin-check__results"></div>
 
 </div>

--- a/templates/results-table.php
+++ b/templates/results-table.php
@@ -1,29 +1,47 @@
-<h4><?php esc_html_e( 'FILE:', 'plugin-check' ); ?> {{ data.file }}</h4>
-<table id="plugin-check__results-table-{{data.index}}" class="widefat striped plugin-check__results-table">
-	<thead>
-		<tr>
-			<td>
-				<?php esc_html_e( 'Line', 'plugin-check' ); ?>
-			</td>
-			<td>
-				<?php esc_html_e( 'Column', 'plugin-check' ); ?>
-			</td>
-			<td>
-				<?php esc_html_e( 'Type', 'plugin-check' ); ?>
-			</td>
-			<td>
-				<?php esc_html_e( 'Code', 'plugin-check' ); ?>
-			</td>
-			<td>
-				<?php esc_html_e( 'Message', 'plugin-check' ); ?>
-			</td>
-			<# if ( data.hasLinks ) { #>
-				<td>
-					<?php esc_html_e( 'Edit Link', 'plugin-check' ); ?>
-				</td>
-			<# } #>
-		</tr>
-	</thead>
-	<tbody id="plugin-check__results-body-{{data.index}}"></tbody>
-</table>
-<br>
+<div class="plugin-check__file-results">
+	<div class="plugin-check__file-results-header">
+		<button
+			type="button"
+			class="plugin-check__file-results-toggle"
+			aria-expanded="true"
+			aria-controls="plugin-check__results-panel-{{data.index}}"
+		>
+			<span class="plugin-check__file-results-leading">
+				<span class="plugin-check__file-results-file-icon dashicons dashicons-media-default" aria-hidden="true"></span>
+				<span class="plugin-check__file-results-label">
+					<?php esc_html_e( 'FILE:', 'plugin-check' ); ?> {{ data.file }}
+				</span>
+			</span>
+			<span class="plugin-check__file-results-toggle-icon dashicons dashicons-arrow-down-alt2" aria-hidden="true"></span>
+		</button>
+	</div>
+	<div id="plugin-check__results-panel-{{data.index}}" class="plugin-check__file-results-panel open">
+		<table id="plugin-check__results-table-{{data.index}}" class="widefat striped plugin-check__results-table">
+			<thead>
+				<tr>
+					<td>
+						<?php esc_html_e( 'Line', 'plugin-check' ); ?>
+					</td>
+					<td>
+						<?php esc_html_e( 'Column', 'plugin-check' ); ?>
+					</td>
+					<td>
+						<?php esc_html_e( 'Type', 'plugin-check' ); ?>
+					</td>
+					<td>
+						<?php esc_html_e( 'Code', 'plugin-check' ); ?>
+					</td>
+					<td>
+						<?php esc_html_e( 'Message', 'plugin-check' ); ?>
+					</td>
+					<# if ( data.hasLinks ) { #>
+						<td>
+							<?php esc_html_e( 'Edit Link', 'plugin-check' ); ?>
+						</td>
+					<# } #>
+				</tr>
+			</thead>
+			<tbody id="plugin-check__results-body-{{data.index}}"></tbody>
+		</table>
+	</div>
+</div>


### PR DESCRIPTION
Summary
Adds collapsible per-file result panels on the Plugin Check admin screen, with Collapse All / Expand All controls shown only when file result tables exist.

Changes
- Wrap each file’s results in a collapsible card (design: file icon, header bar, chevron, animated panel height).
- Add Collapse All / Expand All in a toolbar below export buttons; visible only after checks finish and only if at least one file table was rendered.
- Animate expand/collapse with interpolate-size and height transitions.
- Keep export button behavior unchanged (innerHTML reset on export container only).

Files
- templates/results-table.php,
- templates/admin-page.php
- assets/js/plugin-check-admin.js
- assets/css/plugin-check-admin.css
- includes/Admin/Admin_Page.php

Test plan
-  Run check on plugin with issues → panels toggle; Collapse/Expand All work (including false positives).
-  Run check with no issues → export row may show; Collapse/Expand All hidden.
-  New check resets toolbar until complete again.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Ftools.php%3Fpage%3Dplugin-check%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fplugin-check%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1346-04a31e021afc4486944645435b013c554f602b17.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->