### PR TITLE
Fix #1311: Reduce false positives for loop variable prefix warnings

### DIFF
--- a/includes/Checker/Checks/Plugin_Repo/Prefixing_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Prefixing_Check.php
@@ -26,6 +26,14 @@ class Prefixing_Check extends Abstract_PHP_CodeSniffer_Check {
 	use Stable_Check;
 
 	/**
+	 * Cache of file contents for line-level checks.
+	 *
+	 * @since n.e.x.t
+	 * @var array<string, array<int, string>>
+	 */
+	private $file_line_cache = array();
+
+	/**
 	 * Gets the categories for the check.
 	 *
 	 * Every check must have at least one category.
@@ -106,10 +114,105 @@ class Prefixing_Check extends Abstract_PHP_CodeSniffer_Check {
 	 * @param int          $severity Severity level. Default is 5.
 	 */
 	protected function add_result_message_for_file( Check_Result $result, $error, $message, $code, $file, $line = 0, $column = 0, string $docs = '', $severity = 5 ) {
+		// Suppress false positives where a variable sits inside a `foreach` `as` clause
+		// or a `for` loop initializer at the top level of a file. PHPCS' WPCS sniff
+		// treats these as global variable definitions because the enclosing function
+		// early-return does not apply to file top-level scope, but they are loop-local.
+		if ( 'WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound' === $code
+			&& $this->is_variable_in_loop_control( $file, $line )
+		) {
+			return;
+		}
+
 		// Update error type and severity.
 		$error    = false;
 		$severity = 6;
 
 		parent::add_result_message_for_file( $result, $error, $message, $code, $file, $line, $column, $docs, $severity );
+	}
+
+	/**
+	 * Determines whether the variable on the given file/line sits inside a
+	 * `foreach` `as` clause or a `for` loop initializer.
+	 *
+	 * Used to filter out false-positive prefix warnings for loop-local variables
+	 * at the top level of a plugin file, where the WPCS sniff's normal
+	 * function-scope early-return does not apply.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $file Absolute path to the file.
+	 * @param int    $line 1-based line number to inspect.
+	 * @return bool True when the variable lives inside a loop control structure.
+	 */
+	private function is_variable_in_loop_control( $file, $line ) {
+		if ( $line <= 0 || ! is_string( $file ) || '' === $file || ! file_exists( $file ) ) {
+			return false;
+		}
+
+		if ( ! isset( $this->file_line_cache[ $file ] ) ) {
+			$contents = file_get_contents( $file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			if ( false === $contents ) {
+				return false;
+			}
+			$this->file_line_cache[ $file ] = preg_split( '/\r\n|\r|\n/', $contents );
+		}
+
+		$lines = $this->file_line_cache[ $file ];
+		if ( ! isset( $lines[ $line - 1 ] ) ) {
+			return false;
+		}
+
+		$source = $lines[ $line - 1 ];
+
+		// Single-line cases.
+		// foreach ( ... as $key => $value ).
+		if ( preg_match( '/\bforeach\s*\([^)]*\bas\s+\$/', $source ) ) {
+			return true;
+		}
+
+		// for ( $i = 0, $j = 10; ... ) — match any `$var =` inside the parens.
+		if ( preg_match( '/\bfor\s*\([^)]*?\$\w+\s*=/', $source ) ) {
+			return true;
+		}
+
+		// Multi-line cases: the `foreach` or `for` opener sits on a
+		// previous line (with the opening parenthesis unclosed on that
+		// line) and the parenthesised header continues onto the
+		// reported line. Look back up to 10 lines for the opener.
+		// If we hit a `;` or `}` before the opener, we're not in the
+		// same statement.
+		$min_back = max( 0, $line - 11 );
+		for ( $i = $line - 2; $i >= $min_back; $i-- ) {
+			if ( ! isset( $lines[ $i ] ) ) {
+				continue;
+			}
+			if ( preg_match( '/\b(foreach|for)\s*\(\s*$/', $lines[ $i ] ) ) {
+				// Opener found. Walk forward from opener+1 to current line.
+				// If we find `as` keyword, this is a foreach header.
+				// If we find `$var =` before any `;`, this is a for-init.
+				// Stop if we hit a `;` (end of statement) or `)` (end of parens).
+				for ( $j = $i + 1; $j <= $line; $j++ ) {
+					if ( ! isset( $lines[ $j ] ) ) {
+						continue;
+					}
+					$scan = $lines[ $j ];
+					if ( preg_match( '/\bas\b/', $scan ) ) {
+						return true; // Foreach header found.
+					}
+					if ( preg_match( '/\$\w+\s*=/', $scan ) ) {
+						return true; // For-init found.
+					}
+					if ( strpos( $scan, ';' ) !== false ) {
+						break; // End of statement, not in this loop header.
+					}
+					if ( strpos( $scan, ')' ) !== false ) {
+						break; // End of parens.
+					}
+				}
+			}
+		}
+
+		return false;
 	}
 }

--- a/includes/Checker/Checks/Plugin_Repo/Prefixing_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Prefixing_Check.php
@@ -165,54 +165,99 @@ class Prefixing_Check extends Abstract_PHP_CodeSniffer_Check {
 
 		$source = $lines[ $line - 1 ];
 
-		// Single-line cases.
-		// foreach ( ... as $key => $value ).
+		if ( $this->is_in_single_line_loop_header( $source ) ) {
+			return true;
+		}
+
+		return $this->is_in_multiline_loop_header( $lines, $line );
+	}
+
+	/**
+	 * Checks whether a single source line contains a `foreach ... as $var` or
+	 * `for ( ... $var = ...` loop header.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $source Source line content.
+	 * @return bool True when the line is a single-line loop header.
+	 */
+	private function is_in_single_line_loop_header( $source ) {
+		// foreach ( $items as $key => $value ).
 		if ( preg_match( '/\bforeach\s*\([^)]*\bas\s+\$/', $source ) ) {
 			return true;
 		}
 
-		// for ( $i = 0, $j = 10; ... ) — match any `$var =` inside the parens.
+		// for ( $i = 0, $j = 10; ... ) — match any `$var =` inside parens.
 		if ( preg_match( '/\bfor\s*\([^)]*?\$\w+\s*=/', $source ) ) {
 			return true;
 		}
 
-		// Multi-line cases: the `foreach` or `for` opener sits on a
-		// previous line (with the opening parenthesis unclosed on that
-		// line) and the parenthesised header continues onto the
-		// reported line. Look back up to 10 lines for the opener.
-		// If we hit a `;` or `}` before the opener, we're not in the
-		// same statement.
+		return false;
+	}
+
+	/**
+	 * Checks whether the reported line is part of a multi-line `foreach` or
+	 * `for` header whose opener sits on a previous line.
+	 *
+	 * Looks back up to 10 lines for `foreach (` or `for (` with an unclosed
+	 * opening parenthesis, then walks forward to the reported line checking
+	 * for the `as` keyword (foreach) or `$var =` initializer (for).
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param array<int, string> $lines File contents split by line.
+	 * @param int                $line  1-based line number being inspected.
+	 * @return bool True when the line is inside a multi-line loop header.
+	 */
+	private function is_in_multiline_loop_header( $lines, $line ) {
 		$min_back = max( 0, $line - 11 );
+
 		for ( $i = $line - 2; $i >= $min_back; $i-- ) {
 			if ( ! isset( $lines[ $i ] ) ) {
 				continue;
 			}
-			if ( preg_match( '/\b(foreach|for)\s*\(\s*$/', $lines[ $i ] ) ) {
-				// Opener found. Walk forward from opener+1 to current line.
-				// If we find `as` keyword, this is a foreach header.
-				// If we find `$var =` before any `;`, this is a for-init.
-				// Stop if we hit a `;` (end of statement) or `)` (end of parens).
-				for ( $j = $i + 1; $j <= $line; $j++ ) {
-					if ( ! isset( $lines[ $j ] ) ) {
-						continue;
-					}
-					$scan = $lines[ $j ];
-					if ( preg_match( '/\bas\b/', $scan ) ) {
-						return true; // Foreach header found.
-					}
-					if ( preg_match( '/\$\w+\s*=/', $scan ) ) {
-						return true; // For-init found.
-					}
-					if ( strpos( $scan, ';' ) !== false ) {
-						break; // End of statement, not in this loop header.
-					}
-					if ( strpos( $scan, ')' ) !== false ) {
-						break; // End of parens.
-					}
-				}
+			if ( ! preg_match( '/\b(foreach|for)\s*\(\s*$/', $lines[ $i ] ) ) {
+				continue;
+			}
+			if ( $this->loop_header_contains_variable( $lines, $i + 1, $line ) ) {
+				return true;
 			}
 		}
 
+		return false;
+	}
+
+	/**
+	 * Walks forward from the loop opener to the reported line and checks
+	 * for an `as` keyword (foreach) or `$var =` initializer (for) before
+	 * any statement-terminating `;` or paren-closing `)`.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param array<int, string> $lines File contents split by line.
+	 * @param int                $start 1-based line index just after the opener.
+	 * @param int                $end   1-based line index of the reported line.
+	 * @return bool True when a loop header variable is found.
+	 */
+	private function loop_header_contains_variable( $lines, $start, $end ) {
+		for ( $j = $start; $j <= $end; $j++ ) {
+			if ( ! isset( $lines[ $j - 1 ] ) ) {
+				continue;
+			}
+			$scan = $lines[ $j - 1 ];
+			if ( preg_match( '/\bas\b/', $scan ) ) {
+				return true;
+			}
+			if ( preg_match( '/\$\w+\s*=/', $scan ) ) {
+				return true;
+			}
+			if ( strpos( $scan, ';' ) !== false ) {
+				return false;
+			}
+			if ( strpos( $scan, ')' ) !== false ) {
+				return false;
+			}
+		}
 		return false;
 	}
 }

--- a/tests/phpunit/testdata/plugins/test-plugin-prefixing-foreach/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-prefixing-foreach/load.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Plugin Name: Test Plugin Prefixing Foreach
+ * Plugin URI: https://github.com/WordPress/plugin-check
+ * Description: Test plugin for the Prefixing check loop variable false positives.
+ * Requires at least: 6.0
+ * Requires PHP: 7.2
+ * Version: 1.0.0
+ * Author: WordPress Performance Team
+ * Author URI: https://make.wordpress.org/performance/
+ * License: GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ * Text Domain: test-plugin-prefixing-foreach
+ *
+ * @package test-plugin-prefixing-foreach
+ */
+
+$items = array( 'a', 'b', 'c' );
+
+// foreach: $key and $value are loop-local, must not be flagged.
+foreach ( $items as $key => $value ) {
+	echo $value;
+}
+
+// foreach without key: $value is loop-local, must not be flagged.
+foreach ( $items as $value ) {
+	echo $value;
+}
+
+// for: $i is loop-local, must not be flagged.
+for ( $i = 0; $i < 10; $i++ ) {
+	echo $i;
+}
+
+// Multi-line foreach: opener on previous line, $key/$value on the
+// `as` line. Both loop-local, must not be flagged.
+foreach (
+	$items
+	as $key => $value
+) {
+	echo $value;
+}
+
+// Multi-line for: opener on previous line, $i on the init line.
+// Loop-local, must not be flagged.
+for (
+	$i = 0;
+	$i < 10;
+	$i++
+) {
+	echo $i;
+}
+
+// Multi-line foreach with split `as` and `$var` on different lines.
+// Opener on line 1, `as` on line 3, `$key` on line 4. $key is still
+// a loop header variable, must not be flagged.
+foreach (
+	$items
+	as
+	$key => $value
+) {
+	echo $value;
+}
+
+// Multi-line for with multi-init on different lines. $i and $j both
+// declared in init; both loop-local, must not be flagged.
+for (
+	$i = 0,
+	$j = 10;
+	$i < $j;
+	$i++, $j--
+) {
+	echo $i;
+}
+
+function test_pp_foreach_helper() {
+	return true;
+}

--- a/tests/phpunit/tests/Checker/Checks/Prefixing_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Prefixing_Check_Tests.php
@@ -28,4 +28,34 @@ class Prefixing_Check_Tests extends WP_UnitTestCase {
 		$this->assertCount( 1, wp_list_filter( $warnings['load.php'][28][1], array( 'code' => 'WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound' ) ) );
 		$this->assertCount( 1, wp_list_filter( $warnings['load.php'][41][1], array( 'code' => 'WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound' ) ) );
 	}
+
+	public function test_loop_variables_not_flagged() {
+		$check         = new Prefixing_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-prefixing-foreach/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$check->run( $check_result );
+
+		$warnings = $check_result->get_warnings();
+
+		// Single-line foreach/for header lines: variables declared in
+		// `as $key => $value` or `for ( $i = 0; ...` are loop-local and
+		// must not be reported.
+		$this->assertArrayNotHasKey( 21, $warnings['load.php'] ?? array() );
+		$this->assertArrayNotHasKey( 26, $warnings['load.php'] ?? array() );
+		$this->assertArrayNotHasKey( 31, $warnings['load.php'] ?? array() );
+
+		// Multi-line foreach/for with `as`/`$var` on the same line.
+		$this->assertArrayNotHasKey( 39, $warnings['load.php'] ?? array() );
+		$this->assertArrayNotHasKey( 47, $warnings['load.php'] ?? array() );
+
+		// Multi-line foreach with `as` and `$var` on separate lines.
+		// $key on line 60 is still a loop header variable.
+		$this->assertArrayNotHasKey( 60, $warnings['load.php'] ?? array() );
+
+		// Multi-line for with multi-init on separate lines.
+		// $i (line 68) and $j (line 69) are both init expressions.
+		$this->assertArrayNotHasKey( 68, $warnings['load.php'] ?? array() );
+		$this->assertArrayNotHasKey( 69, $warnings['load.php'] ?? array() );
+	}
 }


### PR DESCRIPTION
## Summary

Filter out `WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound` for variables declared inside `foreach` `as` clauses and `for` loop initializers at top-level scope. WPCS treats these as global declarations but they are loop-local.

Fixes #1311

## Changes

### Prefixing_Check.php

Added `is_variable_in_loop_control()` helper to detect when a variable sits inside a loop control structure. Covers:

- Single-line `foreach ( ... as $var )` and `for ( $i = 0; ... )`
- Multi-line headers where `foreach (` / `for (` opens on previous line (up to 10-line look-back, walk-forward scan from opener to reported line)

Uses file line cache for efficiency across multiple checks.

### Test fixtures

Added `test-plugin-prefixing-foreach/load.php` with 78 lines covering 7 cases:

- Single-line foreach (with and without key)
- Single-line for
- Multi-line foreach
- Multi-line for
- Multi-line foreach with split `as` and `$var` on different lines
- Multi-line for with multi-init on separate lines
- Prefixed helper function (still valid)

### Tests

Added `test_loop_variables_not_flagged()` in `Prefixing_Check_Tests.php` with assertions for all 7 loop variable lines.

## Testing

**Existing tests**: `npm run test-php` — 477 tests pass, 1355 assertions.
**Lint**: `composer lint` — clean.
**Static analysis**: `composer phpstan` — OK, no errors.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Ftools.php%3Fpage%3Dplugin-check%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fplugin-check%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1349-13b0914b8eff34df1aefb62f52d9edfc376e0236.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->