### PR TITLE
Fix "configure an AI connector" link on Settings page to point to the Connectors screen

### DIFF
--- a/includes/Admin/Settings_Page.php
+++ b/includes/Admin/Settings_Page.php
@@ -168,7 +168,7 @@ final class Settings_Page {
 					$configured_connector_message = sprintf(
 						/* translators: %s: URL to WordPress AI settings. */
 						__( 'No AI connectors are configured. Please <a href="%s">configure an AI connector</a> in WordPress settings first.', 'plugin-check' ),
-						esc_url( admin_url( 'options-general.php' ) )
+						esc_url( admin_url( 'options-connectors.php' ) )
 					);
 
 					echo wp_kses(


### PR DESCRIPTION
## What?
<!-- Link this PR to its associated issue. -->
Closes: [1357](https://github.com/WordPress/plugin-check/issues/1357)
Fixes the "configure an AI connector" link on the Plugin Check Settings page so it points to the WordPress core Connectors screen (`options-connectors.php`) instead of General Settings (`options-general.php`).

<!-- In a few words, what is the PR actually doing? -->

## Why?
On **Settings → Plugin Check**, when no AI connector is configured, the AI Code Review section shows this notice:

> No AI connectors are configured. Please **configure an AI connector** in WordPress settings first.

The link currently points to `admin_url( 'options-general.php' )` (Settings → General), which contains no AI/connector settings — users following it land on an unrelated screen with no way forward, making the AI Code Review feature hard to enable.

The intended target is the core **Connectors** screen, which this plugin already links to correctly in `includes/Admin/Namer_Page.php` (the "Configure AI Connectors" button uses `admin_url( 'options-connectors.php' )`). The translator comment on the string ("URL to WordPress AI settings") also confirms the AI settings screen was the intended destination.

## How?
One-line change in `includes/Admin/Settings_Page.php` (the notice rendered in
the AI Code Review section):

```diff
- esc_url( admin_url( 'options-general.php' ) )
+ esc_url( admin_url( 'options-connectors.php' ) )
```

This matches the existing, correct usage in `Namer_Page.php`. No string
changes, so there is no translation impact. The other two
`options-general.php` references in the codebase are intentionally untouched:
the `add_submenu_page()` parent slug in `Settings_Page.php` and the
`settingsPageUrl` (with `?page=plugin-check-settings`) in `Admin_Page.php`
both correctly refer to Plugin Check's own settings page.

## Testing Instructions
1. Use a WordPress 7.0 install with **no AI connector configured**.
2. Install and activate Plugin Check (this branch).
3. Go to **Settings → Plugin Check**.
4. In the **AI Code Review** section, click the **"configure an AI connector"**
   link inside the warning notice.
5. **Before this PR:** the link opens Settings → General
   (`options-general.php`), which has no connector settings.
   **After this PR:** the link opens the Connectors settings screen
   (`options-connectors.php`), consistent with the "Configure AI Connectors"
   button on the Plugin Namer page.

## AI Usage Disclosure
<!-- See the WordPress AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/ -->

- [x ] This PR was created without the help of AI tools
- [ ] This PR includes AI-assisted code or content

If AI tools were used, please describe how they were used:
<!-- e.g., "Used GitHub Copilot for code suggestions", "Used ChatGPT to draft documentation" -->

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|<!-- Before screenshot -->|
<img width="1710" height="982" alt="before-screenshot" src="https://github.com/user-attachments/assets/fe4818ff-7145-41b0-ba83-b0ad1975396c" />
<!-- After screenshot -->| After
<img width="1710" height="1024" alt="after-screenshot" src="https://github.com/user-attachments/assets/27fb5810-ea10-469a-b4d8-ac7aa4a50109" />

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Ftools.php%3Fpage%3Dplugin-check%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fplugin-check%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1358-feb225d02d6bc54e8404e82724e0ca929de2f8b4.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->