### PR TITLE
Fix compatibility false positive on function_exists guarded calls

### DIFF
--- a/includes/Checker/Checks/Plugin_Repo/WP_Functions_Compatibility_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/WP_Functions_Compatibility_Check.php
@@ -308,32 +308,48 @@ class WP_Functions_Compatibility_Check extends Abstract_File_Check {
 				continue;
 			}
 
-			$open_index = $this->get_next_significant_token_index( $tokens, $index );
-			if ( null === $open_index || '(' !== $tokens[ $open_index ] ) {
-				continue;
-			}
-
-			if ( ! $this->is_global_function_call( $tokens, $index ) ) {
-				continue;
-			}
-
-			$argument_index = $this->get_next_significant_token_index( $tokens, $open_index );
-			if ( null === $argument_index ) {
-				continue;
-			}
-
-			$argument_token = $tokens[ $argument_index ];
-			if ( ! is_array( $argument_token ) || T_CONSTANT_ENCAPSED_STRING !== $argument_token[0] ) {
-				continue;
-			}
-
-			$guarded_name = strtolower( ltrim( trim( $argument_token[1], '\'"' ), '\\' ) );
-			if ( '' !== $guarded_name ) {
+			$guarded_name = $this->resolve_function_exists_argument( $tokens, $index );
+			if ( null !== $guarded_name ) {
 				$guarded[ $guarded_name ] = true;
 			}
 		}
 
 		return $guarded;
+	}
+
+	/**
+	 * Resolves the string literal argument of a function_exists() call to a function name.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param array $tokens Token stream.
+	 * @param int   $index  Index of the function_exists T_STRING token.
+	 * @return string|null Lowercase function name, or null when the call is not a
+	 *                     global function_exists() with a single string literal argument.
+	 */
+	private function resolve_function_exists_argument( array $tokens, int $index ): ?string {
+		$open_index = $this->get_next_significant_token_index( $tokens, $index );
+		if ( null === $open_index || '(' !== $tokens[ $open_index ] ) {
+			return null;
+		}
+
+		if ( ! $this->is_global_function_call( $tokens, $index ) ) {
+			return null;
+		}
+
+		$argument_index = $this->get_next_significant_token_index( $tokens, $open_index );
+		if ( null === $argument_index ) {
+			return null;
+		}
+
+		$argument_token = $tokens[ $argument_index ];
+		if ( ! is_array( $argument_token ) || T_CONSTANT_ENCAPSED_STRING !== $argument_token[0] ) {
+			return null;
+		}
+
+		$guarded_name = strtolower( ltrim( trim( $argument_token[1], '\'"' ), '\\' ) );
+
+		return '' !== $guarded_name ? $guarded_name : null;
 	}
 
 	/**

--- a/includes/Checker/Checks/Plugin_Repo/WP_Functions_Compatibility_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/WP_Functions_Compatibility_Check.php
@@ -252,8 +252,9 @@ class WP_Functions_Compatibility_Check extends Abstract_File_Check {
 			return array();
 		}
 
-		$tokens = token_get_all( $source );
-		$calls  = array();
+		$tokens            = token_get_all( $source );
+		$guarded_functions = $this->get_function_exists_guarded_names( $tokens );
+		$calls             = array();
 
 		foreach ( $tokens as $index => $token ) {
 			if ( ! is_array( $token ) || T_STRING !== $token[0] ) {
@@ -269,13 +270,70 @@ class WP_Functions_Compatibility_Check extends Abstract_File_Check {
 				continue;
 			}
 
+			$function_name = strtolower( $token[1] );
+
+			// Skip calls that are guarded by a function_exists() check for the same
+			// function anywhere in the file. This is a documented backward
+			// compatibility pattern, so the call is never reached on WordPress
+			// versions that lack the function.
+			if ( isset( $guarded_functions[ $function_name ] ) ) {
+				continue;
+			}
+
 			$calls[] = array(
-				'name' => strtolower( $token[1] ),
+				'name' => $function_name,
 				'line' => (int) $token[2],
 			);
 		}
 
 		return $calls;
+	}
+
+	/**
+	 * Collects function names guarded by a function_exists() call within the file.
+	 *
+	 * Only string literal arguments are considered, since a dynamic argument cannot
+	 * be resolved to a specific function name through tokenization.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param array $tokens Token stream.
+	 * @return array<string, true> Map of guarded function names, keyed by lowercase name.
+	 */
+	private function get_function_exists_guarded_names( array $tokens ): array {
+		$guarded = array();
+
+		foreach ( $tokens as $index => $token ) {
+			if ( ! is_array( $token ) || T_STRING !== $token[0] || 'function_exists' !== strtolower( $token[1] ) ) {
+				continue;
+			}
+
+			$open_index = $this->get_next_significant_token_index( $tokens, $index );
+			if ( null === $open_index || '(' !== $tokens[ $open_index ] ) {
+				continue;
+			}
+
+			if ( ! $this->is_global_function_call( $tokens, $index ) ) {
+				continue;
+			}
+
+			$argument_index = $this->get_next_significant_token_index( $tokens, $open_index );
+			if ( null === $argument_index ) {
+				continue;
+			}
+
+			$argument_token = $tokens[ $argument_index ];
+			if ( ! is_array( $argument_token ) || T_CONSTANT_ENCAPSED_STRING !== $argument_token[0] ) {
+				continue;
+			}
+
+			$guarded_name = strtolower( ltrim( trim( $argument_token[1], '\'"' ), '\\' ) );
+			if ( '' !== $guarded_name ) {
+				$guarded[ $guarded_name ] = true;
+			}
+		}
+
+		return $guarded;
 	}
 
 	/**

--- a/tests/phpunit/testdata/plugins/test-plugin-wp-functions-compatibility-with-function-exists-guard/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-wp-functions-compatibility-with-function-exists-guard/load.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Plugin Name: Test Plugin WP Functions Compatibility With function_exists Guard
+ * Plugin URI: https://github.com/WordPress/plugin-check
+ * Description: Test plugin for WordPress functions compatibility check where a newer function is guarded by function_exists().
+ * Requires at least: 5.0
+ * Requires PHP: 7.4
+ * Tested up to: 5.4
+ * Version: 1.0.0
+ * Author: WordPress Performance Team
+ * Author URI: https://make.wordpress.org/performance/
+ * License: GPL-2.0-or-later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain: test-plugin-wp-functions-compatibility-with-function-exists-guard
+ *
+ * @package test-plugin-wp-functions-compatibility-with-function-exists-guard
+ */
+
+require_once __DIR__ . '/uses-guarded-function.php';

--- a/tests/phpunit/testdata/plugins/test-plugin-wp-functions-compatibility-with-function-exists-guard/uses-guarded-function.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-wp-functions-compatibility-with-function-exists-guard/uses-guarded-function.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Test file with a newer WordPress function guarded by function_exists().
+ *
+ * The guard and the call live in different methods of the same file, wired
+ * together through add_action(), mirroring the real-world deferred hook pattern.
+ *
+ * @package test-plugin-wp-functions-compatibility-with-function-exists-guard
+ */
+
+class Guarded_Feature {
+
+	public function __construct() {
+		if ( function_exists( 'wp_get_environment_type' ) ) {
+			add_action( 'init', array( $this, 'run' ) );
+		}
+	}
+
+	public function run() {
+		wp_get_environment_type();
+	}
+}

--- a/tests/phpunit/tests/Checker/Checks/WP_Functions_Compatibility_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/WP_Functions_Compatibility_Check_Tests.php
@@ -35,6 +35,17 @@ class WP_Functions_Compatibility_Check_Tests extends WP_UnitTestCase {
 		$this->assertEmpty( wp_list_filter( $errors['uses-compatible-function.php'][8][0] ?? array(), array( 'code' => 'wp_function_not_compatible_with_requires_wp' ) ) );
 	}
 
+	public function test_run_with_function_exists_guard_without_errors() {
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-wp-functions-compatibility-with-function-exists-guard/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$check = new WP_Functions_Compatibility_Check();
+		$check->run( $check_result );
+
+		$errors = $check_result->get_errors();
+		$this->assertArrayNotHasKey( 'uses-guarded-function.php', $errors );
+	}
+
 	public function test_run_with_php_serialize_without_errors() {
 		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-wp-functions-compatibility-with-php-serialize/load.php' );
 		$check_result  = new Check_Result( $check_context );


### PR DESCRIPTION
## What?

Closes #1363

`WP_Functions_Compatibility_Check` no longer reports a function call as incompatible with the plugin's minimum WordPress version when that function is guarded by a `function_exists()` check in the same file.

## Why?

The check finds calls by tokenizing the file with `token_get_all()` and matching any `T_STRING` followed by `(`. It has no control flow analysis, so it cannot see that a call is protected by a `function_exists()` guard. That produces a false positive for a documented backward compatibility pattern: the guarded call never runs on WordPress versions that lack the function.

The reported example guards in `__construct()` and calls in a separate `add()` method wired through `add_action()`, so the guard and the call live in different methods. A narrow "guard wraps the call" rule would not catch that case, which is why this works at the file level.

## How?

A new pass collects every function name guarded by a `function_exists( 'name' )` string literal in the file, then the call scan skips any call whose name is in that set. Only string literal arguments are trusted, since a dynamic argument cannot be resolved to a name through tokenization. Matching is case-insensitive and tolerates a leading namespace separator.

The trade off is a rare false negative if a file guards a function in one place but also calls it unconditionally elsewhere. That is the safe direction for a linter, since a false positive pushes people to disable the whole check. For reference, PHPCompatibility's equivalent sniff does not honor `function_exists()` guards either, so this is more forgiving than that baseline.

## Testing Instructions

1. Create a plugin with `Requires at least: 4.9.6` in its header.
2. Add a class that guards a newer function and calls it from a hooked method:

```php
class Guarded_Feature {
	public function __construct() {
		if ( function_exists( 'register_block_type' ) ) {
			add_action( 'init', array( \$this, 'run' ) );
		}
	}
	public function run() {
		register_block_type( 'my-plugin/gallery', array() );
	}
}
```

3. Run `wp plugin check your-plugin --checks=wp_functions_compatibility`.
4. Expected: no errors. Previously: `wp_function_not_compatible_with_requires_wp` reported on the `register_block_type()` line.
5. Remove the `function_exists()` guard and run the check again. Expected: the error returns, confirming unguarded calls are still flagged.

The PR adds a `test-plugin-wp-functions-compatibility-with-function-exists-guard` fixture and a `test_run_with_function_exists_guard_without_errors` case covering the guarded pattern.

## AI Usage Disclosure
<!-- See the WordPress AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/ -->

- [X] This PR was created without the help of AI tools.
- [ ] This PR includes AI-assisted code or content.

If AI tools were used, please describe how they were used:

## Changelog entry

> Fix - False positive in WordPress function compatibility check when the call is guarded by function_exists()

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Ftools.php%3Fpage%3Dplugin-check%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fplugin-check%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1364-ed6e29c6c2140bf31ece6de65e318d24bce21fbc.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->