### PR TITLE
Add trademark for-use regression test

### DIFF
--- a/tests/phpunit/testdata/plugins/test-trademarks-plugin-header-for-woocommerce-middle/load.php
+++ b/tests/phpunit/testdata/plugins/test-trademarks-plugin-header-for-woocommerce-middle/load.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Plugin Name: Do Something for WooCommerce and Xyz
+ * Plugin URI: https://github.com/WordPress/plugin-check
+ * Description: Test plugin for the Trademarks check.
+ * Requires at least: 6.0
+ * Requires PHP: 5.6
+ * Version: 1.0.0
+ * Author: WordPress Performance Team
+ * Author URI: https://make.wordpress.org/performance/
+ * License: GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ * Text Domain: test-trademarks-plugin-header-for-woocommerce-middle
+ *
+ * @package test-trademarks-plugin-header-for-woocommerce-middle
+ */

--- a/tests/phpunit/tests/Checker/Checks/Trademarks_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Trademarks_Check_Tests.php
@@ -115,6 +115,19 @@ class Trademarks_Check_Tests extends WP_UnitTestCase {
 		$this->assertSame( 0, $check_result->get_warning_count() );
 	}
 
+	public function test_trademarks_with_for_woocommerce_exception_in_middle_of_name() {
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-trademarks-plugin-header-for-woocommerce-middle/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$check = new Trademarks_Check( Trademarks_Check::TYPE_NAME );
+		$check->run( $check_result );
+
+		$warnings = $check_result->get_warnings();
+
+		$this->assertEmpty( $warnings );
+		$this->assertSame( 0, $check_result->get_warning_count() );
+	}
+
 	public function test_single_file_plugin_without_error_for_trademarks() {
 		$trademarks_check = new Trademarks_Check();
 		$check_context    = new Check_Context( WP_PLUGIN_DIR . '/single-file-plugin.php' );


### PR DESCRIPTION
## Summary
- Add a regression fixture for the plugin name reported in #977: `Do Something for WooCommerce and Xyz`.
- Confirm that `for WooCommerce` is accepted when it appears in the middle of the plugin name.
- Keep existing duplicate trademark coverage intact through the current bad-case fixture.

Fixes #977.

## Testing
- `php -l tests/phpunit/tests/Checker/Checks/Trademarks_Check_Tests.php`
- `php -l tests/phpunit/testdata/plugins/test-trademarks-plugin-header-for-woocommerce-middle/load.php`
- `vendor/bin/phpcs --standard=phpcs.xml.dist tests/phpunit/tests/Checker/Checks/Trademarks_Check_Tests.php tests/phpunit/testdata/plugins/test-trademarks-plugin-header-for-woocommerce-middle/load.php`
- PHP 8.4 Docker harness against `validate_name_has_no_trademarks()`: issue example allowed; duplicate WooCommerce case still rejected.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Ftools.php%3Fpage%3Dplugin-check%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fplugin-check%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1372-590fa54cb5d49525043c8258ace40aa94c29a734.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->