### PR TITLE
Add Autoloaded_Options_Check for missing $autoload parameter

### DIFF
--- a/docs/checks.md
+++ b/docs/checks.md
@@ -36,4 +36,5 @@
 | enqueued_styles_scope | performance | Checks whether any stylesheets are loaded on all pages, which is usually not desirable and can lead to performance issues. | [Learn more](https://developer.wordpress.org/plugins/) |
 | enqueued_scripts_scope | performance | Checks whether any scripts are loaded on all pages, which is usually not desirable and can lead to performance issues. | [Learn more](https://developer.wordpress.org/plugins/) |
 | non_blocking_scripts | performance | Checks whether scripts and styles are enqueued using a recommended loading strategy. | [Learn more](https://developer.wordpress.org/plugins/) |
+| autoloaded_options | performance | Warns when <code>add_option()</code> or <code>update_option()</code> are called without explicitly setting the <code>$autoload</code> parameter. | [Learn more](https://developer.wordpress.org/reference/functions/add_option/) |
 | ai_provider | general | Recommends the WordPress AI Client when a plugin integrates directly with a third-party AI provider. | [Learn more](https://developer.wordpress.org/plugins/) |

--- a/includes/Checker/Checks/Performance/Autoloaded_Options_Check.php
+++ b/includes/Checker/Checks/Performance/Autoloaded_Options_Check.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Class Autoloaded_Options_Check.
+ *
+ * @package plugin-check
+ */
+
+namespace WordPress\Plugin_Check\Checker\Checks\Performance;
+
+use WordPress\Plugin_Check\Checker\Check_Categories;
+use WordPress\Plugin_Check\Checker\Check_Result;
+use WordPress\Plugin_Check\Checker\Checks\Abstract_PHP_CodeSniffer_Check;
+use WordPress\Plugin_Check\Traits\Stable_Check;
+
+/**
+ * Check to detect missing $autoload parameter on add_option() / update_option().
+ *
+ * @since 2.1.0
+ */
+class Autoloaded_Options_Check extends Abstract_PHP_CodeSniffer_Check {
+
+	use Stable_Check;
+
+	/**
+	 * Gets the categories for the check.
+	 *
+	 * Every check must have at least one category.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @return array The categories for the check.
+	 */
+	public function get_categories() {
+		return array( Check_Categories::CATEGORY_PERFORMANCE );
+	}
+
+	/**
+	 * Returns an associative array of arguments to pass to PHPCS.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param Check_Result $result The check result to amend, including the plugin context to check.
+	 * @return array An associative array of PHPCS CLI arguments.
+	 */
+	protected function get_args( Check_Result $result ) {
+		return array(
+			'extensions' => 'php',
+			'standard'   => 'PluginCheck',
+			'sniffs'     => 'PluginCheck.CodeAnalysis.AutoLoadedOptions',
+		);
+	}
+
+	/**
+	 * Gets the description for the check.
+	 *
+	 * Every check must have a short description explaining what the check does.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @return string Description.
+	 */
+	public function get_description(): string {
+		return __( 'Warns when add_option() or update_option() are called without explicitly setting the $autoload parameter.', 'plugin-check' );
+	}
+
+	/**
+	 * Gets the documentation URL for the check.
+	 *
+	 * Every check must have a URL with further information about the check.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @return string The documentation URL.
+	 */
+	public function get_documentation_url(): string {
+		return __( 'https://developer.wordpress.org/reference/functions/add_option/', 'plugin-check' );
+	}
+}

--- a/includes/Checker/Default_Check_Repository.php
+++ b/includes/Checker/Default_Check_Repository.php
@@ -104,6 +104,7 @@ class Default_Check_Repository extends Empty_Check_Repository {
 				'direct_file_access'         => new Checks\Plugin_Repo\Direct_File_Access_Check(),
 				'external_admin_menu_links'  => new Checks\Plugin_Repo\External_Admin_Menu_Links_Check(),
 				'wp_functions_compatibility' => new Checks\Plugin_Repo\WP_Functions_Compatibility_Check(),
+				'autoloaded_options'         => new Checks\Performance\Autoloaded_Options_Check(),
 				'ai_provider'                => new Checks\General\AI_Provider_Check(),
 			)
 		);

--- a/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/AutoLoadedOptionsSniff.php
+++ b/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/AutoLoadedOptionsSniff.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * AutoLoadedOptionsSniff
+ *
+ * Based on code from {@link https://github.com/WordPress/WordPress-Coding-Standards}
+ * which is licensed under {@link https://opensource.org/licenses/MIT}.
+ *
+ * @package PluginCheck
+ */
+
+namespace PluginCheckCS\PluginCheck\Sniffs\CodeAnalysis;
+
+use PHPCSUtils\Utils\MessageHelper;
+use PHPCSUtils\Utils\PassedParameters;
+use WordPressCS\WordPress\AbstractFunctionParameterSniff;
+
+/**
+ * Warns when add_option() / update_option() are called without explicitly
+ * setting the $autoload parameter.
+ *
+ * The default value of $autoload is true, which loads the option on every
+ * page request. Plugins that accumulate autoloaded options slow down every
+ * request. Letting the author choose explicitly is the goal.
+ *
+ * @link https://developer.wordpress.org/reference/functions/add_option/
+ * @link https://developer.wordpress.org/reference/functions/update_option/
+ *
+ * @since 2.1.0
+ */
+final class AutoLoadedOptionsSniff extends AbstractFunctionParameterSniff {
+
+	/**
+	 * Position of the $autoload parameter for each target function.
+	 *
+	 * add_option() is `add_option( $option, $value, $deprecated, $autoload )`
+	 * update_option() is `update_option( $option, $value, $autoload )`.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @var array<string, int>
+	 */
+	protected $autoload_positions = array(
+		'add_option'    => 4,
+		'update_option' => 3,
+	);
+
+	/**
+	 * List of functions to examine.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @var array<string, true>
+	 */
+	protected $target_functions = array(
+		'add_option'    => true,
+		'update_option' => true,
+	);
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 * @return int|void Integer stack pointer to skip forward or void to continue normal file processing.
+	 */
+	public function process_token( $stackPtr ) {
+		if ( isset( $this->target_functions[ strtolower( $this->tokens[ $stackPtr ]['content'] ) ] ) ) {
+			$this->exclude = array();
+
+			return parent::process_token( $stackPtr );
+		}
+	}
+
+	/**
+	 * Process the parameters of a matched function call.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param string $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched in lowercase.
+	 * @param array  $parameters      Array with information about the parameters.
+	 * @return void
+	 */
+	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
+		$position = $this->autoload_positions[ $matched_content ];
+		$found    = PassedParameters::getParameterFromStack( $parameters, $position, 'autoload' );
+
+		if ( false === $found ) {
+			$error_code = MessageHelper::stringToErrorcode( $matched_content . '_autoload', true );
+
+			$this->phpcsFile->addWarning(
+				'The $autoload parameter for %s() is not explicitly set; the option will default to autoloading on every page request. Pass an explicit boolean (true or false) to make the performance trade-off intentional.',
+				$stackPtr,
+				$error_code . 'Missing',
+				array( $matched_content )
+			);
+		}
+	}
+}

--- a/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/AutoLoadedOptionsSniff.php
+++ b/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/AutoLoadedOptionsSniff.php
@@ -32,8 +32,8 @@ final class AutoLoadedOptionsSniff extends AbstractFunctionParameterSniff {
 	/**
 	 * Position of the $autoload parameter for each target function.
 	 *
-	 * add_option() is `add_option( $option, $value, $deprecated, $autoload )`
-	 * update_option() is `update_option( $option, $value, $autoload )`.
+	 * Add_option() is `add_option( $option, $value, $deprecated, $autoload )`.
+	 * Update_option() is `update_option( $option, $value, $autoload )`.
 	 *
 	 * @since 2.1.0
 	 *

--- a/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/AutoLoadedOptionsUnitTest.inc
+++ b/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/AutoLoadedOptionsUnitTest.inc
@@ -1,0 +1,28 @@
+<?php
+
+// Bad: add_option() with no $autoload.
+add_option( 'no_autoload_a' ); // Warning.
+
+// Bad: add_option() with only $value set.
+add_option( 'no_autoload_b', 'value' ); // Warning.
+
+// Bad: add_option() with only $deprecated set.
+add_option( 'no_autoload_c', 'value', '' ); // Warning.
+
+// Bad: update_option() with no $autoload.
+update_option( 'no_autoload_d' ); // Warning.
+
+// Bad: update_option() with only $value set.
+update_option( 'no_autoload_e', 'value' ); // Warning.
+
+// Good: add_option() with explicit autoload = false.
+add_option( 'autoload_false_a', 'value', '', false );
+
+// Good: add_option() with explicit autoload = true.
+add_option( 'autoload_true_a', 'value', '', true );
+
+// Good: update_option() with explicit autoload = false.
+update_option( 'autoload_false_b', 'value', false );
+
+// Good: update_option() with explicit autoload = true.
+update_option( 'autoload_true_b', 'value', true );

--- a/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/AutoLoadedOptionsUnitTest.php
+++ b/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/AutoLoadedOptionsUnitTest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Unit tests for AutoLoadedOptionsSniff.
+ *
+ * @package PluginCheck
+ */
+
+namespace PluginCheckCS\PluginCheck\Tests\CodeAnalysis;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PluginCheckCS\PluginCheck\Sniffs\CodeAnalysis\AutoLoadedOptionsSniff;
+use PluginCheckCS\PluginCheck\Tests\AbstractSniffUnitTest;
+
+/**
+ * Unit tests for AutoLoadedOptionsSniff.
+ */
+final class AutoLoadedOptionsUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array();
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array(
+			4  => 1,
+			7  => 1,
+			10 => 1,
+			13 => 1,
+			16 => 1,
+		);
+	}
+
+	/**
+	 * Returns the fully qualified class name (FQCN) of the sniff.
+	 *
+	 * @return string The fully qualified class name of the sniff.
+	 */
+	protected function get_sniff_fqcn() {
+		return AutoLoadedOptionsSniff::class;
+	}
+
+	/**
+	 * Sets the parameters for the sniff.
+	 *
+	 * @throws \RuntimeException If unable to set the ruleset parameters required for the test.
+	 *
+	 * @param Sniff $sniff The sniff being tested.
+	 */
+	public function set_sniff_parameters( Sniff $sniff ) {
+	}
+}

--- a/phpcs-sniffs/PluginCheck/ruleset.xml
+++ b/phpcs-sniffs/PluginCheck/ruleset.xml
@@ -4,6 +4,7 @@
 	<description>Plugin Check Sniffs</description>
 
 	<rule ref="PluginCheck.CodeAnalysis.AIProvider" />
+	<rule ref="PluginCheck.CodeAnalysis.AutoLoadedOptions" />
 	<rule ref="PluginCheck.CodeAnalysis.DiscouragedFunctions" />
 	<rule ref="PluginCheck.CodeAnalysis.EnqueuedResourceOffloading" />
 	<rule ref="PluginCheck.CodeAnalysis.Heredoc" />

--- a/tests/phpunit/testdata/plugins/test-plugin-autoloaded-options-check-with-errors/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-autoloaded-options-check-with-errors/load.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Plugin Name: Test Plugin Autoloaded Options check with errors
+ * Plugin URI: https://github.com/WordPress/plugin-check
+ * Description: Test plugin for the Autoloaded Options check.
+ * Requires at least: 6.0
+ * Requires PHP: 5.6
+ * Version: 1.0.0
+ * Author: WordPress Performance Team
+ * Author URI: https://make.wordpress.org/performance/
+ * License: GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ * Text Domain: test-plugin-autoloaded-options-check-with-errors
+ *
+ * @package test-plugin-autoloaded-options-check-with-errors
+ */
+
+// add_option without $autoload.
+add_option( 'autoloaded_with_errors_a' );
+
+// add_option with $value but no $autoload.
+add_option( 'autoloaded_with_errors_b', 'value' );
+
+// update_option without $autoload.
+update_option( 'autoloaded_with_errors_c' );
+
+// update_option with $value but no $autoload.
+update_option( 'autoloaded_with_errors_d', 'value' );

--- a/tests/phpunit/testdata/plugins/test-plugin-autoloaded-options-check-without-errors/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-autoloaded-options-check-without-errors/load.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Plugin Name: Test Plugin Autoloaded Options check without errors
+ * Plugin URI: https://github.com/WordPress/plugin-check
+ * Description: Test plugin for the Autoloaded Options check (clean fixture).
+ * Requires at least: 6.0
+ * Requires PHP: 5.6
+ * Version: 1.0.0
+ * Author: WordPress Performance Team
+ * Author URI: https://make.wordpress.org/performance/
+ * License: GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ * Text Domain: test-plugin-autoloaded-options-check-without-errors
+ *
+ * @package test-plugin-autoloaded-options-check-without-errors
+ */
+
+// add_option with explicit autoload = false.
+add_option( 'autoloaded_without_errors_a', 'value', '', false );
+
+// add_option with explicit autoload = true.
+add_option( 'autoloaded_without_errors_b', 'value', '', true );
+
+// update_option with explicit autoload = false.
+update_option( 'autoloaded_without_errors_c', 'value', false );
+
+// update_option with explicit autoload = true.
+update_option( 'autoloaded_without_errors_d', 'value', true );

--- a/tests/phpunit/tests/Checker/Checks/Autoloaded_Options_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Autoloaded_Options_Check_Tests.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Tests for the Autoloaded_Options_Check class.
+ *
+ * @package plugin-check
+ */
+
+use WordPress\Plugin_Check\Checker\Check_Context;
+use WordPress\Plugin_Check\Checker\Check_Result;
+use WordPress\Plugin_Check\Checker\Checks\Performance\Autoloaded_Options_Check;
+
+class Autoloaded_Options_Check_Tests extends WP_UnitTestCase {
+
+	public function test_run_with_errors() {
+		$check         = new Autoloaded_Options_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-autoloaded-options-check-with-errors/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$check->run( $check_result );
+
+		$warnings = $check_result->get_warnings();
+
+		$this->assertNotEmpty( $warnings );
+		$this->assertArrayHasKey( 'load.php', $warnings );
+
+		// Both add_option calls without $autoload must produce warnings.
+		$this->assertSame(
+			'PluginCheck.CodeAnalysis.AutoLoadedOptions.add_option_autoloadMissing',
+			$warnings['load.php'][19][1][0]['code']
+		);
+		$this->assertSame(
+			'PluginCheck.CodeAnalysis.AutoLoadedOptions.add_option_autoloadMissing',
+			$warnings['load.php'][22][1][0]['code']
+		);
+
+		// Both update_option calls without $autoload must produce warnings.
+		$this->assertSame(
+			'PluginCheck.CodeAnalysis.AutoLoadedOptions.update_option_autoloadMissing',
+			$warnings['load.php'][25][1][0]['code']
+		);
+		$this->assertSame(
+			'PluginCheck.CodeAnalysis.AutoLoadedOptions.update_option_autoloadMissing',
+			$warnings['load.php'][28][1][0]['code']
+		);
+	}
+
+	public function test_run_without_errors() {
+		$check         = new Autoloaded_Options_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-autoloaded-options-check-without-errors/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$check->run( $check_result );
+
+		$this->assertEmpty( $check_result->get_errors() );
+		$this->assertEmpty( $check_result->get_warnings() );
+	}
+}


### PR DESCRIPTION
## What?

Closes #28

Adds a new check, `autoloaded_options`, that warns plugin authors when `add_option()` or `update_option()` is called without explicitly setting the `$autoload` parameter.

## Why?

When the `$autoload` parameter is omitted, WordPress determines the value based on the WordPress version and whether the option already exists. This implicit decision can lead to options being loaded on every page request, which can bloat the `alloptions` row and slow down requests. Letting the author choose explicitly makes the performance trade-off intentional.

## How?

Custom PHPCS sniff `PluginCheck.CodeAnalysis.AutoLoadedOptions` that wraps `AbstractFunctionParameterSniff`. The sniff targets the two call sites (the `$autoload` parameter sits at position 4 on `add_option` after a deprecated arg, and at position 3 on `update_option`). Calls without an explicit `$autoload` produce a single warning per call site; an explicit boolean `true` or `false` is left untouched, including the WP 6.6+ recommendation to pass boolean autoload instead of `'yes'`/`'no'` strings.

A new check class `Autoloaded_Options_Check` registers the sniff under the `performance` category. It is wired into `Default_Check_Repository` under the `autoloaded_options` slug.

Files touched:

- `phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/AutoLoadedOptionsSniff.php` (new sniff)
- `phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/AutoLoadedOptionsUnitTest.{inc,php}` (sniff unit test)
- `phpcs-sniffs/PluginCheck/ruleset.xml` (registers the new rule)
- `includes/Checker/Checks/Performance/Autoloaded_Options_Check.php` (check class)
- `includes/Checker/Default_Check_Repository.php` (registration)
- `docs/checks.md` (new row)
- `tests/phpunit/testdata/plugins/test-plugin-autoloaded-options-check-{with,without}-errors/load.php` (PHPUnit fixtures)
- `tests/phpunit/tests/Checker/Checks/Autoloaded_Options_Check_Tests.php` (PHPUnit integration test)

## Testing Instructions

1. Apply the patch and activate plugin-check in a WordPress install.
2. Run `wp plugin-check list-checks` and confirm `autoloaded_options` is listed in the `performance` category.
3. Create a test plugin containing both forms below and run `wp plugin-check check <plugin>` on it.
   - Triggers a warning:
     ```php
     add_option( 'opt_a' );
     add_option( 'opt_b', 'value' );
     update_option( 'opt_c' );
     update_option( 'opt_d', 'value' );
     ```
   - Clean (no warning):
     ```php
     add_option( 'opt_a', 'value', '', false );
     add_option( 'opt_b', 'value', '', true );
     update_option( 'opt_c', 'value', false );
     update_option( 'opt_d', 'value', true );
     ```
4. Verify four warnings appear on the first plugin (codes `PluginCheck.CodeAnalysis.AutoLoadedOptions.add_option_autoloadMissing` and `PluginCheck.CodeAnalysis.AutoLoadedOptions.update_option_autoloadMissing`) and zero autoloaded_options results on the second.

Automated tests:

- `composer test` runs the PHPUnit integration tests against both fixtures.
- Sniff unit test runs via `cd phpcs-sniffs && php vendor/bin/phpunit vendor/squizlabs/php_codesniffer/tests/AllTests.php --filter AutoLoadedOptions --no-coverage`.

## AI Usage Disclosure

- [ ] This PR was created without the help of AI tools
- [x] This PR includes AI-assisted code or content

If AI tools were used, please describe how they were used:
Used Claude Code for code generation, refactoring and documentation drafting under direction of maintainer.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Ftools.php%3Fpage%3Dplugin-check%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fplugin-check%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1413-73e6f50c3bb83746368a0f37c3cd4965e9959c28.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->
