### PR TITLE
fix: Plugin "Check it!" button fails silently with nonce error  #893

### DIFF
--- a/assets/js/plugin-check-admin.js
+++ b/assets/js/plugin-check-admin.js
@@ -86,7 +86,7 @@
 		pluginsList.disabled = true;
 		spinner.classList.add( 'is-active' );
 		clientError.innerText = '';
-		clientError.classList.add("is-hidden");
+		clientError.classList.add( 'is-hidden' );
 
 		for ( let i = 0; i < categoriesList.length; i++ ) {
 			categoriesList[ i ].disabled = true;
@@ -112,7 +112,7 @@
 			} )
 			.catch( ( error ) => {
 				clientError.innerText = error.message;
-				clientError.classList.remove("is-hidden");
+				clientError.classList.remove( 'is-hidden' );
 				console.error( error );
 
 				resetForm();

--- a/assets/js/plugin-check-admin.js
+++ b/assets/js/plugin-check-admin.js
@@ -113,6 +113,8 @@
 			.catch( ( error ) => {
 				clientError.innerText = error.message;
 				clientError.classList.remove( 'is-hidden' );
+				clientError.focus();
+				
 				console.error( error );
 
 				resetForm();

--- a/assets/js/plugin-check-admin.js
+++ b/assets/js/plugin-check-admin.js
@@ -114,7 +114,7 @@
 				clientError.innerText = error.message;
 				clientError.classList.remove( 'is-hidden' );
 				clientError.focus();
-				
+
 				console.error( error );
 
 				resetForm();

--- a/assets/js/plugin-check-admin.js
+++ b/assets/js/plugin-check-admin.js
@@ -5,6 +5,7 @@
 		'plugin-check__export-controls'
 	);
 	const spinner = document.getElementById( 'plugin-check__spinner' );
+	const clientError = document.getElementById( 'plugin-check__client-error' );
 	const pluginsList = document.getElementById(
 		'plugin-check__plugins-dropdown'
 	);
@@ -21,6 +22,7 @@
 		! resultsContainer ||
 		! exportContainer ||
 		! spinner ||
+		! clientError ||
 		! categoriesList.length ||
 		! typesList.length
 	) {
@@ -83,6 +85,9 @@
 		checkItButton.disabled = true;
 		pluginsList.disabled = true;
 		spinner.classList.add( 'is-active' );
+		clientError.innerText = '';
+		clientError.classList.add("is-hidden");
+
 		for ( let i = 0; i < categoriesList.length; i++ ) {
 			categoriesList[ i ].disabled = true;
 		}
@@ -106,6 +111,8 @@
 				resetForm();
 			} )
 			.catch( ( error ) => {
+				clientError.innerText = error.message;
+				clientError.classList.remove("is-hidden");
 				console.error( error );
 
 				resetForm();

--- a/includes/Admin/Admin_Page.php
+++ b/includes/Admin/Admin_Page.php
@@ -434,6 +434,10 @@ final class Admin_Page {
 			.plugin-check__export-controls.is-hidden {
 				display: none;
 			}
+			/** Plugin Check Client Errors **/
+			#plugin-check__client-error.is-hidden {
+				display: none;
+			}
 		</style>
 		<?php
 	}

--- a/templates/admin-page.php
+++ b/templates/admin-page.php
@@ -39,6 +39,7 @@
 
 				<input type="submit" value="<?php esc_attr_e( 'Check it!', 'plugin-check' ); ?>" id="plugin-check__submit" class="button button-primary" />
 				<span id="plugin-check__spinner" class="spinner" style="float: none;"></span>
+				<div class="notice notice-error is-hidden" id="plugin-check__client-error"></div>
 				<div class="plugin-check__options">
 					<div>
 						<h4><?php esc_attr_e( 'Categories', 'plugin-check' ); ?></h4>

--- a/templates/admin-page.php
+++ b/templates/admin-page.php
@@ -39,7 +39,7 @@
 
 				<input type="submit" value="<?php esc_attr_e( 'Check it!', 'plugin-check' ); ?>" id="plugin-check__submit" class="button button-primary" />
 				<span id="plugin-check__spinner" class="spinner" style="float: none;"></span>
-				<div class="notice notice-error is-hidden" id="plugin-check__client-error"></div>
+				<div class="notice notice-error is-hidden" role="alert" tabindex="-1" id="plugin-check__client-error"></div>
 				<div class="plugin-check__options">
 					<div>
 						<h4><?php esc_attr_e( 'Categories', 'plugin-check' ); ?></h4>


### PR DESCRIPTION
## What?
<!-- Link this PR to its associated issue. -->
Closes #893 

The changes in this PR are to add a custom error notice in the UI instead of showing the error in the console when an error occurs in the catch block.

## Why?
The issue mentioned above shows how, after some time, when the nonce gets expired, the check plugin button does not work and shows an invalid nonce message in the console. So, the solution is either to tell the user about the nonce expiration on the client side visually or reload the page automatically. As reloading the page won't be a consistent solution, I decided to show an admin error notice informing the user that the nonce has expired.

## How?
My suggested solution is to show the error message from the server side directly as an admin error notice so the user can understand why the plugin check is failing. 

## Testing Instructions
1. Open 'Plugin Check' from Dashboard > Tools.
2. Open Browser DevTools and paste `PLUGIN_CHECK.nonce = 'gg'` and press Enter to make the nonce invalid.
3. Select any plugin and click the "Check It!" button to check the plugin.
4. The admin error notice will be visible with the error message from the server side.

## AI Usage Disclosure
<!-- See the WordPress AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/ -->

- [x] This PR was created without the help of AI tools
- [ ] This PR includes AI-assisted code or content

If AI tools were used, please describe how they were used:
AI tools used in this PR only to modify the PR message to ensure no grammar mistake included in the message.

|Before|After|
|-|-|
|<img width="1919" height="875" alt="image" src="https://github.com/user-attachments/assets/c0d431d5-7ba6-421d-985c-61c283312415" />|<img width="1919" height="894" alt="image" src="https://github.com/user-attachments/assets/18c39706-f7b6-402b-83a7-70f4251340f1" />|

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Ftools.php%3Fpage%3Dplugin-check%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fplugin-check%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1418-0c31eb8faabf4868fe130fc52534073bec82fec2.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->


Unlinked contributors: tamimhasan19702, rtpHarry.

Co-authored-by: kmfoysal06 <kmfoysal06@git.wordpress.org>
Co-authored-by: iyut <aralle@git.wordpress.org>