### PR TITLE
Add SVN Checker Admin Page

### DIFF
--- a/assets/css/plugin-check-svn-checker.css
+++ b/assets/css/plugin-check-svn-checker.css
@@ -1,0 +1,91 @@
+.plugin-check-svn-checker-wrap {
+	max-width: 1200px;
+}
+.plugin-check-svn-checker-wrap .plugin-check-svn-checker-inner {
+	margin-top: 10px;
+}
+
+/* ---------- Search form ---------- */
+.plugin-check-svn-checker-form {
+	margin-bottom: 20px;
+}
+.plugin-check-svn-checker-search-row {
+	display: flex;
+	gap: 8px;
+	align-items: center;
+}
+.plugin-check-svn-checker-search-row .spinner {
+	float: none;
+	margin: 0;
+}
+.plugin-check-svn-checker-slug-input {
+	flex: 1;
+	max-width: 400px;
+}
+
+/* ---------- Plugin name ---------- */
+.plugin-check-svn-checker-plugin-name {
+	font-size: 16px;
+	font-weight: 600;
+	margin-bottom: 16px;
+}
+
+/* ---------- SVN external link in section heading ---------- */
+.plugin-check-svn-checker-svn-link {
+	vertical-align: middle;
+	text-decoration: none;
+}
+.plugin-check-svn-checker-svn-link .dashicons {
+	font-size: 20px;
+	width: 20px;
+	height: 20px;
+}
+
+/* ---------- Inline checks (root section) ---------- */
+.plugin-check-svn-checker-inline-checks {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 16px;
+	margin-bottom: 20px;
+}
+
+/* ---------- Checks table ---------- */
+.plugin-check-svn-checker-col-status {
+	width: 90px;
+}
+.plugin-check-svn-checker-col-check {
+	width: 40%;
+}
+
+.plugin-check-svn-checker-row-warn td {
+	background: #fffcf0 !important;
+}
+.plugin-check-svn-checker-row-fail td {
+	background: #fff5f5 !important;
+}
+
+/* ---------- Status badge ---------- */
+.plugin-check-svn-checker-badge-pass {
+	color: #00a32a;
+}
+.plugin-check-svn-checker-badge-warn {
+	color: #c07a00;
+}
+.plugin-check-svn-checker-badge-fail {
+	color: #d63638;
+}
+.plugin-check-svn-checker-badge-info {
+	color: #2271b1;
+}
+
+/* ---------- Detail text ---------- */
+.plugin-check-svn-checker-detail-text {
+	font-size: 13px;
+	font-family: monospace;
+}
+
+@media (max-width: 782px) {
+	.plugin-check-svn-checker-col-detail {
+		display: none;
+	}
+}

--- a/assets/css/plugin-check-svn-checker.css
+++ b/assets/css/plugin-check-svn-checker.css
@@ -5,7 +5,6 @@
 	margin-top: 10px;
 }
 
-/* ---------- Search form ---------- */
 .plugin-check-svn-checker-form {
 	margin-bottom: 20px;
 }
@@ -23,14 +22,13 @@
 	max-width: 400px;
 }
 
-/* ---------- Plugin name ---------- */
 .plugin-check-svn-checker-plugin-name {
-	font-size: 16px;
+	font-size: 1.3em;
 	font-weight: 600;
+	color: #1d2327;
 	margin-bottom: 16px;
 }
 
-/* ---------- SVN external link in section heading ---------- */
 .plugin-check-svn-checker-svn-link {
 	vertical-align: middle;
 	text-decoration: none;
@@ -41,7 +39,6 @@
 	height: 20px;
 }
 
-/* ---------- Inline checks (root section) ---------- */
 .plugin-check-svn-checker-inline-checks {
 	display: flex;
 	flex-wrap: wrap;
@@ -49,7 +46,6 @@
 	margin-bottom: 20px;
 }
 
-/* ---------- Checks table ---------- */
 .plugin-check-svn-checker-col-status {
 	width: 90px;
 }
@@ -64,7 +60,6 @@
 	background: #fff5f5 !important;
 }
 
-/* ---------- Status badge ---------- */
 .plugin-check-svn-checker-badge-pass {
 	color: #00a32a;
 }
@@ -78,7 +73,6 @@
 	color: #2271b1;
 }
 
-/* ---------- Detail text ---------- */
 .plugin-check-svn-checker-detail-text {
 	font-size: 13px;
 	font-family: monospace;

--- a/assets/js/plugin-check-svn-checker.js
+++ b/assets/js/plugin-check-svn-checker.js
@@ -1,0 +1,171 @@
+/* global pluginCheckSvnChecker */
+( function () {
+	'use strict';
+
+	const form = document.getElementById( 'plugin-check-svn-checker-form' );
+	const result = document.getElementById( 'plugin-check-svn-checker-result' );
+
+	if ( ! form || ! result ) {
+		return;
+	}
+
+	const spinner = document.getElementById(
+		'plugin-check-svn-checker-spinner'
+	);
+	const { i18n } = pluginCheckSvnChecker;
+
+	form.addEventListener( 'submit', async ( e ) => {
+		e.preventDefault();
+
+		const slug = document
+			.getElementById( 'plugin-check-svn-checker-slug-input' )
+			.value.trim();
+
+		result.innerHTML = '';
+		spinner.classList.add( 'is-active' );
+
+		try {
+			const params = new URLSearchParams();
+			params.set( 'action', pluginCheckSvnChecker.action );
+			params.set( 'nonce', pluginCheckSvnChecker.nonce );
+			params.set( 'slug', slug );
+
+			const res = await fetch( pluginCheckSvnChecker.ajaxUrl, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+				body: params,
+			} );
+
+			const { success, data } = await res.json();
+
+			if ( ! success ) {
+				result.innerHTML = `<div class="notice notice-error inline"><p>${ esc(
+					( data && data.message ) || i18n.error
+				) }</p></div>`;
+				return;
+			}
+
+			result.innerHTML = renderReport( data );
+		} catch {
+			result.innerHTML = `<div class="notice notice-error inline"><p>${ esc(
+				i18n.requestFailed
+			) }</p></div>`;
+		} finally {
+			spinner.classList.remove( 'is-active' );
+		}
+	} );
+
+	function renderReport( data ) {
+		const { meta, sections } = data;
+		let html = '';
+
+		if ( meta.plugin_name ) {
+			html += `<p class="plugin-check-svn-checker-plugin-name">${ esc(
+				meta.plugin_name
+			) }</p><hr>`;
+		}
+
+		// Sections.
+		for ( const section of sections ) {
+			if ( ! section.checks.length ) {
+				continue;
+			}
+
+			const svnLink =
+				section.id === 'root' && meta.svn_url
+					? ` <a href="${ esc(
+							meta.svn_url
+					  ) }" target="_blank" rel="noopener" class="plugin-check-svn-checker-svn-link" title="${ esc(
+							i18n.viewInSvn
+					  ) }"><span class="dashicons dashicons-external"></span></a>`
+					: '';
+			html += `<h2>${ esc( section.label ) }${ svnLink }</h2>`;
+
+			if ( section.id === 'root' ) {
+				html += '<div class="plugin-check-svn-checker-inline-checks">';
+				for ( const check of section.checks ) {
+					html += `<span class="plugin-check-svn-checker-inline-check" title="${ esc(
+						check.detail
+					) }">${ badge( check.status ) } ${ esc(
+						check.label
+					) }</span>`;
+				}
+				html += '</div>';
+			} else {
+				html +=
+					'<table class="wp-list-table widefat striped plugin-check-svn-checker-checks-table">' +
+					'<thead><tr>' +
+					`<th class="plugin-check-svn-checker-col-status">${ esc(
+						i18n.colStatus
+					) }</th>` +
+					`<th class="plugin-check-svn-checker-col-check">${ esc(
+						i18n.colCheck
+					) }</th>` +
+					`<th class="plugin-check-svn-checker-col-detail">${ esc(
+						i18n.colDetail
+					) }</th>` +
+					'</tr></thead><tbody>';
+
+				for ( const check of section.checks ) {
+					html += `<tr class="plugin-check-svn-checker-check-row plugin-check-svn-checker-row-${ esc(
+						check.status
+					) }">`;
+					html += `<td class="plugin-check-svn-checker-col-status">${ badge(
+						check.status
+					) }</td>`;
+					html += `<td class="plugin-check-svn-checker-col-check">${ esc(
+						check.label
+					) }</td>`;
+					html += `<td class="plugin-check-svn-checker-col-detail"><span class="plugin-check-svn-checker-detail-text">${ esc(
+						check.detail
+					) }</span></td>`;
+					html += '</tr>';
+				}
+
+				html += '</tbody></table>';
+			}
+		}
+
+		return html;
+	}
+
+	function badge( status ) {
+		const map = {
+			pass: [
+				'dashicons-yes-alt',
+				i18n.pass,
+				'plugin-check-svn-checker-badge-pass',
+			],
+			warn: [
+				'dashicons-info',
+				i18n.warning,
+				'plugin-check-svn-checker-badge-warn',
+			],
+			fail: [
+				'dashicons-dismiss',
+				i18n.fail,
+				'plugin-check-svn-checker-badge-fail',
+			],
+			info: [
+				'dashicons-info',
+				i18n.info,
+				'plugin-check-svn-checker-badge-info',
+			],
+		};
+		const [ icon, label, cls ] = map[ status ] || map.warn;
+		return `<span class="plugin-check-svn-checker-status-badge ${ cls }"><span class="dashicons ${ icon }"></span> ${ esc(
+			label
+		) }</span>`;
+	}
+
+	function esc( str ) {
+		return String( str ?? '' )
+			.replace( /&/g, '&amp;' )
+			.replace( /</g, '&lt;' )
+			.replace( />/g, '&gt;' )
+			.replace( /"/g, '&quot;' )
+			.replace( /'/g, '&#039;' );
+	}
+} )();

--- a/assets/js/plugin-check-svn-checker.js
+++ b/assets/js/plugin-check-svn-checker.js
@@ -12,6 +12,7 @@
 	const spinner = document.getElementById(
 		'plugin-check-svn-checker-spinner'
 	);
+	const submitButton = form.querySelector( 'button[type="submit"]' );
 	const { i18n } = pluginCheckSvnChecker;
 
 	form.addEventListener( 'submit', async ( e ) => {
@@ -23,6 +24,7 @@
 
 		result.innerHTML = '';
 		spinner.classList.add( 'is-active' );
+		submitButton.disabled = true;
 
 		try {
 			const params = new URLSearchParams();
@@ -54,6 +56,7 @@
 			) }</p></div>`;
 		} finally {
 			spinner.classList.remove( 'is-active' );
+			submitButton.disabled = false;
 		}
 	} );
 

--- a/includes/Admin/SVN_Checker_Page.php
+++ b/includes/Admin/SVN_Checker_Page.php
@@ -58,8 +58,8 @@ class SVN_Checker_Page {
 	 */
 	public function add_page(): void {
 		$hook = add_management_page(
-			__( 'Plugin Check SVN Checker', 'plugin-check' ),
-			__( 'Plugin Check SVN Checker', 'plugin-check' ),
+			__( 'SVN Checker', 'plugin-check' ),
+			__( 'Plugin Check SVN', 'plugin-check' ),
 			'manage_options',
 			self::MENU_SLUG,
 			array( $this, 'render_page' )

--- a/includes/Admin/SVN_Checker_Page.php
+++ b/includes/Admin/SVN_Checker_Page.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * SVN_Checker_Page class.
+ *
+ * @package Plugin_Check
+ */
+
+namespace WordPress\Plugin_Check\Admin;
+
+use WordPress\Plugin_Check\SVN\Checker;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class SVN_Checker_Page.
+ *
+ * Registers the SVN Checker menu page and renders the report UI.
+ *
+ * @since 2.1.0
+ */
+class SVN_Checker_Page {
+
+	const MENU_SLUG = 'plugin-check-svn-checker';
+
+	/**
+	 * AJAX action name.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @var string
+	 */
+	const ACTION_CHECK = 'plugin_check_svn_checker_check';
+
+	/**
+	 * Admin page hook.
+	 *
+	 * @var string
+	 */
+	private string $hook_suffix = '';
+
+	/**
+	 * Registers WordPress hooks.
+	 *
+	 * @since 2.1.0
+	 */
+	public function add_hooks() {
+		add_action( 'admin_menu', array( $this, 'add_page' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		add_action( 'wp_ajax_' . self::ACTION_CHECK, array( $this, 'handle_check' ) );
+	}
+
+	/**
+	 * Register admin menu page.
+	 *
+	 * @since 2.1.0
+	 */
+	public function add_page(): void {
+		$hook = add_management_page(
+			__( 'Plugin Check SVN Checker', 'plugin-check' ),
+			__( 'Plugin Check SVN Checker', 'plugin-check' ),
+			'manage_options',
+			self::MENU_SLUG,
+			array( $this, 'render_page' )
+		);
+
+		$this->hook_suffix = (string) $hook;
+	}
+
+	/**
+	 * Enqueue assets only on this plugin's page.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param string $hook_suffix Current admin page hook suffix.
+	 */
+	public function enqueue_scripts( string $hook_suffix ): void {
+		if ( '' === $this->hook_suffix || $this->hook_suffix !== $hook_suffix ) {
+			return;
+		}
+
+		wp_enqueue_style(
+			'plugin-check-svn-checker',
+			WP_PLUGIN_CHECK_PLUGIN_DIR_URL . 'assets/css/plugin-check-svn-checker.css',
+			array(),
+			WP_PLUGIN_CHECK_VERSION
+		);
+
+		wp_enqueue_script(
+			'plugin-check-svn-checker',
+			WP_PLUGIN_CHECK_PLUGIN_DIR_URL . 'assets/js/plugin-check-svn-checker.js',
+			array(),
+			WP_PLUGIN_CHECK_VERSION,
+			true
+		);
+
+		wp_localize_script(
+			'plugin-check-svn-checker',
+			'pluginCheckSvnChecker',
+			array(
+				'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+				'action'  => self::ACTION_CHECK,
+				'nonce'   => wp_create_nonce( self::ACTION_CHECK ),
+				'i18n'    => array(
+					'error'         => __( 'Error', 'plugin-check' ),
+					'enterSlug'     => __( 'Enter plugin slug', 'plugin-check' ),
+					'requestFailed' => __( 'Request failed.', 'plugin-check' ),
+					'viewInSvn'     => __( 'View in SVN', 'plugin-check' ),
+					'colStatus'     => __( 'Status', 'plugin-check' ),
+					'colCheck'      => __( 'Check', 'plugin-check' ),
+					'colDetail'     => __( 'Detail', 'plugin-check' ),
+					'pass'          => __( 'Pass', 'plugin-check' ),
+					'warning'       => __( 'Warning', 'plugin-check' ),
+					'fail'          => __( 'Fail', 'plugin-check' ),
+					'info'          => __( 'Info', 'plugin-check' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Render the page.
+	 *
+	 * @since 2.1.0
+	 */
+	public function render_page(): void {
+		$slug = isset( $_GET['plugin_slug'] ) ? sanitize_title( wp_unslash( $_GET['plugin_slug'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		?>
+		<div class="wrap plugin-check-svn-checker-wrap">
+
+			<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
+
+			<div class="plugin-check-svn-checker-inner">
+
+				<form id="plugin-check-svn-checker-form" class="plugin-check-svn-checker-form">
+					<div class="plugin-check-svn-checker-search-row">
+						<input
+							type="text"
+							name="plugin_slug"
+							id="plugin-check-svn-checker-slug-input"
+							value="<?php echo esc_attr( $slug ); ?>"
+							class="plugin-check-svn-checker-slug-input"
+							placeholder="<?php esc_attr_e( 'Enter plugin slug', 'plugin-check' ); ?>"
+							autocomplete="off"
+							spellcheck="false"
+							required
+						/>
+						<button type="submit" class="button button-primary">
+							<?php echo esc_html( _x( 'Check', 'button label', 'plugin-check' ) ); ?>
+						</button>
+						<span class="spinner" id="plugin-check-svn-checker-spinner"></span>
+					</div>
+				</form>
+
+				<div id="plugin-check-svn-checker-result"></div>
+
+			</div>
+
+		</div>
+		<?php
+	}
+
+	/**
+	 * Handle the AJAX check request.
+	 *
+	 * @since 2.1.0
+	 */
+	public function handle_check(): void {
+		check_ajax_referer( self::ACTION_CHECK, 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Insufficient permissions.', 'plugin-check' ) ), 403 );
+		}
+
+		$slug = isset( $_POST['slug'] ) ? sanitize_title( wp_unslash( $_POST['slug'] ) ) : '';
+
+		if ( empty( $slug ) ) {
+			wp_send_json_error( array( 'message' => __( 'Plugin slug is required.', 'plugin-check' ) ), 400 );
+		}
+
+		$checker = new Checker( $slug );
+		$report  = $checker->run();
+
+		if ( ! empty( $report['meta']['error'] ) ) {
+			wp_send_json_error(
+				array(
+					/* translators: %s: plugin slug. */
+					'message' => sprintf( __( 'Plugin "%s" was not found in the WordPress.org SVN repository.', 'plugin-check' ), $slug ),
+				),
+				404
+			);
+		}
+
+		wp_send_json_success( $report );
+	}
+}

--- a/includes/Plugin_Main.php
+++ b/includes/Plugin_Main.php
@@ -10,6 +10,7 @@ namespace WordPress\Plugin_Check;
 use WordPress\Plugin_Check\Admin\Admin_AJAX;
 use WordPress\Plugin_Check\Admin\Admin_Page;
 use WordPress\Plugin_Check\Admin\Settings_Page;
+use WordPress\Plugin_Check\Admin\SVN_Checker_Page;
 
 /**
  * Main class for the plugin.
@@ -82,5 +83,9 @@ class Plugin_Main {
 		$namer_page_class = '\\WordPress\\Plugin_Check\\Admin\\Namer_Page';
 		$namer_page       = new $namer_page_class();
 		$namer_page->add_hooks();
+
+		// Create the SVN Checker page.
+		$svn_checker_page = new SVN_Checker_Page();
+		$svn_checker_page->add_hooks();
 	}
 }

--- a/includes/SVN/Checker.php
+++ b/includes/SVN/Checker.php
@@ -1,0 +1,426 @@
+<?php
+/**
+ * Checker class.
+ *
+ * @package Plugin_Check
+ */
+
+namespace WordPress\Plugin_Check\SVN;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Checker.
+ *
+ * Fetches data from a WordPress.org plugin SVN repo and builds
+ * structured report data.
+ *
+ * @since 2.1.0
+ */
+class Checker {
+
+	const WP_SVN_BASE = 'https://plugins.svn.wordpress.org/';
+
+	/**
+	 * Plugin slug.
+	 *
+	 * @var string
+	 */
+	private string $slug;
+
+	/**
+	 * Trailing-slash base URL for this plugin's SVN repo.
+	 *
+	 * @var string
+	 */
+	private string $base_url;
+
+	/**
+	 * Fetcher instance.
+	 *
+	 * @var Fetcher
+	 */
+	private Fetcher $fetcher;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param string $input Plugin slug.
+	 */
+	public function __construct( string $input ) {
+		$this->slug     = sanitize_title( trim( $input ) );
+		$this->base_url = self::WP_SVN_BASE . $this->slug . '/';
+		$this->fetcher  = new Fetcher( $this->base_url );
+	}
+
+	/**
+	 * Run all checks and return the report data.
+	 *
+	 * Each remote directory is fetched exactly once; results are reused
+	 * for both existence checks and content analysis.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @return array{slug: string, meta: array<string, mixed>, sections: Section[]}
+	 */
+	public function run(): array {
+		// Attempt trunk/readme.txt, then README.txt, readme.md, README.md.
+		$readme_resp = $this->fetcher->fetch_raw( 'trunk/readme.txt' );
+		if ( 200 !== $readme_resp['code'] ) {
+			$readme_resp = $this->fetcher->fetch_raw( 'trunk/README.txt' );
+		}
+		if ( 200 !== $readme_resp['code'] ) {
+			$readme_resp = $this->fetcher->fetch_raw( 'trunk/readme.md' );
+		}
+		if ( 200 !== $readme_resp['code'] ) {
+			$readme_resp = $this->fetcher->fetch_raw( 'trunk/README.md' );
+		}
+		$readme_ok   = 200 === $readme_resp['code'];
+		$readme_data = $readme_ok ? $this->fetcher->parse_readme( $readme_resp['body'] ) : array();
+
+		// Fetch trunk/ listing for existence check and PHP file discovery (one request).
+		$trunk_dir    = $this->fetcher->fetch_directory( 'trunk/' );
+		$trunk_exists = $trunk_dir['exists'] || $readme_ok;
+
+		// Bail early if the slug doesn't resolve to a valid SVN repo.
+		if ( ! $trunk_exists ) {
+			return array(
+				'slug'     => $this->slug,
+				'meta'     => array(
+					'error'   => 'not_found',
+					'svn_url' => $this->base_url,
+				),
+				'sections' => array(),
+			);
+		}
+
+		// Find main PHP file from the listing; returns content to avoid a second fetch.
+		[ 'file' => $plugin_file, 'content' => $php_content ] =
+			$this->find_main_plugin_file_with_content( $trunk_dir['items'] );
+		$php_data = ! empty( $php_content )
+			? $this->fetcher->parse_plugin_headers( $php_content )
+			: array();
+
+		// Check tags/ existence only — no need to parse the full listing.
+		$tags_exists = 200 === $this->fetcher->fetch_raw( 'tags/' )['code'];
+
+		// Fetch assets/ listing for existence check and asset file scan (one request).
+		$assets_dir    = $this->fetcher->fetch_directory( 'assets/' );
+		$assets_exists = $assets_dir['exists'];
+
+		$stable_tag    = $readme_data['stable_tag'] ?? null;
+		$trunk_version = $php_data['Version'] ?? null;
+
+		$meta = array(
+			'plugin_name'   => $readme_data['name'] ?? null,
+			'plugin_file'   => $plugin_file,
+			'stable_tag'    => $stable_tag,
+			'trunk_version' => $trunk_version,
+			'requires_php'  => $readme_data['requires_php'] ?? null,
+			'tested_up_to'  => $readme_data['tested_up_to'] ?? null,
+			'svn_url'       => $this->base_url,
+		);
+
+		$sections = array();
+
+		// Section: root (no additional requests).
+		$root_section = new Section( 'root', __( 'Main SVN Folder', 'plugin-check' ) );
+		$root_section->add_check( 'root_trunk_exists', __( 'trunk/ exists', 'plugin-check' ), 'pass', __( 'Found', 'plugin-check' ) );
+		$root_section->add_check( 'root_tags_exists', __( 'tags/ exists', 'plugin-check' ), $tags_exists ? 'pass' : 'fail', $tags_exists ? __( 'Found', 'plugin-check' ) : __( 'Missing', 'plugin-check' ) );
+		$root_section->add_check( 'root_assets_exists', __( 'assets/ exists', 'plugin-check' ), $assets_exists ? 'pass' : 'warn', $assets_exists ? __( 'Found', 'plugin-check' ) : __( 'Missing — optional but recommended', 'plugin-check' ) );
+		$sections[] = $root_section;
+
+		// Section: trunk (no additional requests).
+		$trunk_section = new Section( 'trunk', __( 'Trunk', 'plugin-check' ) );
+
+		$trunk_section->add_check(
+			'trunk_readme_found',
+			__( 'readme.txt found', 'plugin-check' ),
+			$readme_ok ? 'pass' : 'fail',
+			$readme_ok
+				? 'trunk/readme.txt'
+				/* translators: %s: file path. */
+				: sprintf( __( '%s is missing', 'plugin-check' ), 'trunk/readme.txt' )
+		);
+
+		$trunk_section->add_check(
+			'trunk_stable_tag_declared',
+			__( 'Stable tag declared', 'plugin-check' ),
+			! empty( $stable_tag ) ? 'pass' : 'fail',
+			! empty( $stable_tag )
+				? $stable_tag
+				/* translators: %s: file path. */
+				: sprintf( __( '"Stable tag:" not found in %s', 'plugin-check' ), 'trunk/readme.txt' )
+		);
+
+		$trunk_section->add_check(
+			'trunk_main_php_file_found',
+			__( 'Main plugin PHP file found', 'plugin-check' ),
+			! empty( $plugin_file ) ? 'pass' : 'warn',
+			! empty( $plugin_file ) ? "trunk/{$plugin_file}" : __( 'No PHP file with "Plugin Name:" header found in trunk/', 'plugin-check' )
+		);
+
+		$trunk_section->add_check(
+			'trunk_version_declared',
+			__( 'Version declared in PHP header', 'plugin-check' ),
+			! empty( $trunk_version ) ? 'pass' : ( $plugin_file ? 'fail' : 'warn' ),
+			! empty( $trunk_version )
+				? $trunk_version
+				: (
+					$plugin_file
+						/* translators: %s: file name. */
+						? sprintf( __( 'No "Version:" header in trunk/%s', 'plugin-check' ), $plugin_file )
+						: __( 'Skipped — plugin PHP file not found', 'plugin-check' )
+				)
+		);
+
+		if ( ! empty( $stable_tag ) && ! empty( $trunk_version ) ) {
+			$match = ( $stable_tag === $trunk_version );
+			$trunk_section->add_check(
+				'trunk_stable_tag_matches_version',
+				__( 'Stable tag matches PHP version', 'plugin-check' ),
+				$match ? 'pass' : 'fail',
+				$match ? "{$stable_tag} === {$trunk_version}" : "readme={$stable_tag}, php={$trunk_version}"
+			);
+		} else {
+			$trunk_section->add_check( 'trunk_stable_tag_matches_version', __( 'Stable tag matches PHP version', 'plugin-check' ), 'warn', __( 'Cannot compare — one or both values missing', 'plugin-check' ) );
+		}
+
+		$sections[] = $trunk_section;
+
+		// Section: stable_tag.
+		if ( $stable_tag ) {
+			$stable_tag_section = new Section( 'stable_tag', "tags/{$stable_tag}/" );
+
+			$tag_exists = 200 === $this->fetcher->fetch_raw( "tags/{$stable_tag}/" )['code'];
+			$stable_tag_section->add_check(
+				'stable_tag_dir_exists',
+				/* translators: %s: SVN tag directory path. */
+				sprintf( __( '%s exists', 'plugin-check' ), "tags/{$stable_tag}/" ),
+				$tag_exists ? 'pass' : 'fail',
+				$tag_exists
+					? __( 'Found', 'plugin-check' )
+					/* translators: %s: SVN tag directory path. */
+					: sprintf( __( '%s not found', 'plugin-check' ), "tags/{$stable_tag}/" )
+			);
+
+			if ( $tag_exists && $plugin_file ) {
+				$this->add_stable_tag_checks( $stable_tag_section, $stable_tag, $plugin_file, $stable_tag, $trunk_version );
+			}
+
+			$sections[] = $stable_tag_section;
+		}
+
+		// Section: assets (pass already-fetched listing).
+		$assets_section = new Section( 'assets', __( 'Assets', 'plugin-check' ) );
+		$this->add_assets_checks( $assets_section, $assets_dir['items'] );
+		$sections[] = $assets_section;
+
+		return array(
+			'slug'     => $this->slug,
+			'meta'     => $meta,
+			'sections' => $sections,
+		);
+	}
+
+	/**
+	 * Add checks for the tags/{stable}/ folder.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param Section     $section       Section to add checks to.
+	 * @param string      $tag           Stable tag version string.
+	 * @param string      $plugin_file   Main plugin PHP filename.
+	 * @param string|null $trunk_stable  Stable tag from trunk/readme.txt.
+	 * @param string|null $trunk_version Version from trunk PHP header.
+	 */
+	private function add_stable_tag_checks(
+		Section $section,
+		string $tag,
+		string $plugin_file,
+		?string $trunk_stable,
+		?string $trunk_version
+	): void {
+		// Attempt readme.txt, then README.txt, readme.md, README.md in tag.
+		$readme_resp = $this->fetcher->fetch_raw( "tags/{$tag}/readme.txt" );
+		if ( 200 !== $readme_resp['code'] ) {
+			$readme_resp = $this->fetcher->fetch_raw( "tags/{$tag}/README.txt" );
+		}
+		if ( 200 !== $readme_resp['code'] ) {
+			$readme_resp = $this->fetcher->fetch_raw( "tags/{$tag}/readme.md" );
+		}
+		if ( 200 !== $readme_resp['code'] ) {
+			$readme_resp = $this->fetcher->fetch_raw( "tags/{$tag}/README.md" );
+		}
+		$readme_ok = 200 === $readme_resp['code'];
+
+		$section->add_check(
+			'tag_readme_found',
+			__( 'readme.txt found', 'plugin-check' ),
+			$readme_ok ? 'pass' : 'fail',
+			$readme_ok
+				? "tags/{$tag}/readme.txt"
+				/* translators: %s: file path. */
+				: sprintf( __( '%s is missing', 'plugin-check' ), "tags/{$tag}/readme.txt" )
+		);
+
+		if ( $readme_ok ) {
+			$readme_data = $this->fetcher->parse_readme( $readme_resp['body'] );
+			$tag_stable  = $readme_data['stable_tag'] ?? null;
+
+			$section->add_check(
+				'tag_stable_tag_declared',
+				__( 'Stable tag declared', 'plugin-check' ),
+				! empty( $tag_stable ) ? 'pass' : 'fail',
+				! empty( $tag_stable ) ? $tag_stable : __( '"Stable tag:" not found', 'plugin-check' )
+			);
+
+			if ( $trunk_stable && $tag_stable ) {
+				$match = ( $tag_stable === $trunk_stable );
+				$section->add_check(
+					'tag_readme_stable_tag_matches_trunk',
+					__( 'readme stable tag matches trunk', 'plugin-check' ),
+					$match ? 'pass' : 'fail',
+					"{$tag_stable} === {$trunk_stable}"
+				);
+			}
+		}
+
+		// Plugin PHP file in tag.
+		$php_resp = $this->fetcher->fetch_raw( "tags/{$tag}/{$plugin_file}" );
+		$php_ok   = 200 === $php_resp['code'];
+
+		$section->add_check(
+			'tag_main_php_file_found',
+			__( 'Main PHP file found', 'plugin-check' ),
+			$php_ok ? 'pass' : 'fail',
+			$php_ok
+				? "tags/{$tag}/{$plugin_file}"
+				/* translators: %s: file path. */
+				: sprintf( __( '%s is missing', 'plugin-check' ), "tags/{$tag}/{$plugin_file}" )
+		);
+
+		if ( $php_ok ) {
+			$php_data    = $this->fetcher->parse_plugin_headers( $php_resp['body'] );
+			$php_version = $php_data['Version'] ?? null;
+
+			$section->add_check(
+				'tag_version_declared',
+				__( 'Version declared', 'plugin-check' ),
+				! empty( $php_version ) ? 'pass' : 'fail',
+				! empty( $php_version ) ? $php_version : __( '"Version:" header not found', 'plugin-check' )
+			);
+
+			if ( $trunk_version && $php_version ) {
+				$match = ( $php_version === $trunk_version );
+				$section->add_check(
+					'tag_php_version_matches_trunk',
+					__( 'PHP version matches trunk', 'plugin-check' ),
+					$match ? 'pass' : 'fail',
+					"{$php_version} === {$trunk_version}"
+				);
+			}
+		}
+	}
+
+	/**
+	 * Add asset presence checks (banner, icon).
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param Section                                                     $section Section to add checks to.
+	 * @param array<int, array{name: string, href: string, is_dir: bool}> $items   Pre-fetched assets/ listing.
+	 */
+	private function add_assets_checks( Section $section, array $items ): void {
+		$filenames = array_column( $items, 'name' );
+
+		$banner_file = null;
+		$icon_file   = null;
+
+		foreach ( $filenames as $name ) {
+			if ( ! $banner_file && preg_match( '/^banner-\d+x\d+\.(png|jpg)$/i', $name ) ) {
+				$banner_file = $name;
+			}
+			if ( ! $icon_file && preg_match( '/^icon(-\d+x\d+\.(png|jpg)|\.svg)$/i', $name ) ) {
+				$icon_file = $name;
+			}
+		}
+
+		$section->add_check(
+			'assets_banner_present',
+			__( 'Banner image present', 'plugin-check' ),
+			$banner_file ? 'pass' : 'info',
+			/* translators: %s: file name pattern. */
+			$banner_file ?? sprintf( __( '%s not found — optional', 'plugin-check' ), 'banner-772x250.(png|jpg)' )
+		);
+
+		$section->add_check(
+			'assets_icon_present',
+			__( 'Icon image present', 'plugin-check' ),
+			$icon_file ? 'pass' : 'info',
+			/* translators: %s: file name pattern. */
+			$icon_file ?? sprintf( __( '%s not found — optional', 'plugin-check' ), 'icon-128x128.(png|jpg) or icon.svg' )
+		);
+	}
+
+	/**
+	 * Find the main plugin PHP file from a pre-fetched trunk/ listing.
+	 *
+	 * Uses the directory listing so no extra HTTP request is needed.
+	 * Prioritises {slug}.php (WP.org convention) but works for any filename.
+	 * Returns both the filename and its content so the caller never re-fetches.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param array<int, array{name: string, href: string, is_dir: bool}> $trunk_items Pre-fetched trunk/ items.
+	 * @return array{file: string|null, content: string}
+	 */
+	private function find_main_plugin_file_with_content( array $trunk_items ): array {
+		$skip     = array( 'uninstall.php' );
+		$slug_php = $this->slug . '.php';
+		$first    = array();
+		$rest     = array();
+
+		foreach ( $trunk_items as $item ) {
+			if ( $item['is_dir'] ) {
+				continue;
+			}
+
+			$name = $item['name'];
+
+			if ( 'php' !== strtolower( pathinfo( $name, PATHINFO_EXTENSION ) ) ) {
+				continue;
+			}
+
+			if ( in_array( $name, $skip, true ) ) {
+				continue;
+			}
+
+			// Keep slug.php as first candidate (convention), everything else after.
+			if ( $name === $slug_php ) {
+				$first[] = $name;
+			} else {
+				$rest[] = $name;
+			}
+		}
+
+		foreach ( array_merge( $first, $rest ) as $name ) {
+			$r = $this->fetcher->fetch_raw( "trunk/{$name}" );
+			if ( 200 === $r['code'] && false !== strpos( $r['body'], 'Plugin Name:' ) ) {
+				return array(
+					'file'    => $name,
+					'content' => $r['body'],
+				);
+			}
+		}
+
+		return array(
+			'file'    => null,
+			'content' => '',
+		);
+	}
+}

--- a/includes/SVN/Checker.php
+++ b/includes/SVN/Checker.php
@@ -68,17 +68,7 @@ class Checker {
 	 * @return array{slug: string, meta: array<string, mixed>, sections: Section[]}
 	 */
 	public function run(): array {
-		// Attempt trunk/readme.txt, then README.txt, readme.md, README.md.
-		$readme_resp = $this->fetcher->fetch_raw( 'trunk/readme.txt' );
-		if ( 200 !== $readme_resp['code'] ) {
-			$readme_resp = $this->fetcher->fetch_raw( 'trunk/README.txt' );
-		}
-		if ( 200 !== $readme_resp['code'] ) {
-			$readme_resp = $this->fetcher->fetch_raw( 'trunk/readme.md' );
-		}
-		if ( 200 !== $readme_resp['code'] ) {
-			$readme_resp = $this->fetcher->fetch_raw( 'trunk/README.md' );
-		}
+		$readme_resp = $this->fetch_readme_fallback( 'trunk/' );
 		$readme_ok   = 200 === $readme_resp['code'];
 		$readme_data = $readme_ok ? $this->fetcher->parse_readme( $readme_resp['body'] ) : array();
 
@@ -115,103 +105,14 @@ class Checker {
 		$stable_tag    = $readme_data['stable_tag'] ?? null;
 		$trunk_version = $php_data['Version'] ?? null;
 
-		$meta = array(
-			'plugin_name'   => $readme_data['name'] ?? null,
-			'plugin_file'   => $plugin_file,
-			'stable_tag'    => $stable_tag,
-			'trunk_version' => $trunk_version,
-			'requires_php'  => $readme_data['requires_php'] ?? null,
-			'tested_up_to'  => $readme_data['tested_up_to'] ?? null,
-			'svn_url'       => $this->base_url,
-		);
+		$meta = $this->build_meta( $readme_data, $plugin_file, $stable_tag, $trunk_version );
 
-		$sections = array();
+		$sections   = array();
+		$sections[] = $this->build_root_section( $tags_exists, $assets_exists );
+		$sections[] = $this->build_trunk_section( $readme_ok, $stable_tag, $plugin_file, $trunk_version );
 
-		// Section: root (no additional requests).
-		$root_section = new Section( 'root', __( 'Main SVN Folder', 'plugin-check' ) );
-		$root_section->add_check( 'root_trunk_exists', __( 'trunk/ exists', 'plugin-check' ), 'pass', __( 'Found', 'plugin-check' ) );
-		$root_section->add_check( 'root_tags_exists', __( 'tags/ exists', 'plugin-check' ), $tags_exists ? 'pass' : 'fail', $tags_exists ? __( 'Found', 'plugin-check' ) : __( 'Missing', 'plugin-check' ) );
-		$root_section->add_check( 'root_assets_exists', __( 'assets/ exists', 'plugin-check' ), $assets_exists ? 'pass' : 'warn', $assets_exists ? __( 'Found', 'plugin-check' ) : __( 'Missing — optional but recommended', 'plugin-check' ) );
-		$sections[] = $root_section;
-
-		// Section: trunk (no additional requests).
-		$trunk_section = new Section( 'trunk', __( 'Trunk', 'plugin-check' ) );
-
-		$trunk_section->add_check(
-			'trunk_readme_found',
-			__( 'readme.txt found', 'plugin-check' ),
-			$readme_ok ? 'pass' : 'fail',
-			$readme_ok
-				? 'trunk/readme.txt'
-				/* translators: %s: file path. */
-				: sprintf( __( '%s is missing', 'plugin-check' ), 'trunk/readme.txt' )
-		);
-
-		$trunk_section->add_check(
-			'trunk_stable_tag_declared',
-			__( 'Stable tag declared', 'plugin-check' ),
-			! empty( $stable_tag ) ? 'pass' : 'fail',
-			! empty( $stable_tag )
-				? $stable_tag
-				/* translators: %s: file path. */
-				: sprintf( __( '"Stable tag:" not found in %s', 'plugin-check' ), 'trunk/readme.txt' )
-		);
-
-		$trunk_section->add_check(
-			'trunk_main_php_file_found',
-			__( 'Main plugin PHP file found', 'plugin-check' ),
-			! empty( $plugin_file ) ? 'pass' : 'warn',
-			! empty( $plugin_file ) ? "trunk/{$plugin_file}" : __( 'No PHP file with "Plugin Name:" header found in trunk/', 'plugin-check' )
-		);
-
-		$trunk_section->add_check(
-			'trunk_version_declared',
-			__( 'Version declared in PHP header', 'plugin-check' ),
-			! empty( $trunk_version ) ? 'pass' : ( $plugin_file ? 'fail' : 'warn' ),
-			! empty( $trunk_version )
-				? $trunk_version
-				: (
-					$plugin_file
-						/* translators: %s: file name. */
-						? sprintf( __( 'No "Version:" header in trunk/%s', 'plugin-check' ), $plugin_file )
-						: __( 'Skipped — plugin PHP file not found', 'plugin-check' )
-				)
-		);
-
-		if ( ! empty( $stable_tag ) && ! empty( $trunk_version ) ) {
-			$match = ( $stable_tag === $trunk_version );
-			$trunk_section->add_check(
-				'trunk_stable_tag_matches_version',
-				__( 'Stable tag matches PHP version', 'plugin-check' ),
-				$match ? 'pass' : 'fail',
-				$match ? "{$stable_tag} === {$trunk_version}" : "readme={$stable_tag}, php={$trunk_version}"
-			);
-		} else {
-			$trunk_section->add_check( 'trunk_stable_tag_matches_version', __( 'Stable tag matches PHP version', 'plugin-check' ), 'warn', __( 'Cannot compare — one or both values missing', 'plugin-check' ) );
-		}
-
-		$sections[] = $trunk_section;
-
-		// Section: stable_tag.
-		if ( $stable_tag ) {
-			$stable_tag_section = new Section( 'stable_tag', "tags/{$stable_tag}/" );
-
-			$tag_exists = 200 === $this->fetcher->fetch_raw( "tags/{$stable_tag}/" )['code'];
-			$stable_tag_section->add_check(
-				'stable_tag_dir_exists',
-				/* translators: %s: SVN tag directory path. */
-				sprintf( __( '%s exists', 'plugin-check' ), "tags/{$stable_tag}/" ),
-				$tag_exists ? 'pass' : 'fail',
-				$tag_exists
-					? __( 'Found', 'plugin-check' )
-					/* translators: %s: SVN tag directory path. */
-					: sprintf( __( '%s not found', 'plugin-check' ), "tags/{$stable_tag}/" )
-			);
-
-			if ( $tag_exists && $plugin_file ) {
-				$this->add_stable_tag_checks( $stable_tag_section, $stable_tag, $plugin_file, $stable_tag, $trunk_version );
-			}
-
+		$stable_tag_section = $this->build_stable_tag_section( $stable_tag, $plugin_file, $trunk_version );
+		if ( $stable_tag_section ) {
 			$sections[] = $stable_tag_section;
 		}
 
@@ -228,35 +129,247 @@ class Checker {
 	}
 
 	/**
-	 * Add checks for the tags/{stable}/ folder.
+	 * Fetch a readme file, trying txt then md, uppercase and lowercase.
 	 *
 	 * @since 2.1.0
 	 *
-	 * @param Section     $section       Section to add checks to.
-	 * @param string      $tag           Stable tag version string.
-	 * @param string      $plugin_file   Main plugin PHP filename.
-	 * @param string|null $trunk_stable  Stable tag from trunk/readme.txt.
+	 * @param string $prefix Path prefix to prepend to the readme filename (e.g. 'trunk/').
+	 * @return array{code: int, body: string}
+	 */
+	private function fetch_readme_fallback( string $prefix ): array {
+		$readme_resp = $this->fetcher->fetch_raw( "{$prefix}readme.txt" );
+		if ( 200 !== $readme_resp['code'] ) {
+			$readme_resp = $this->fetcher->fetch_raw( "{$prefix}README.txt" );
+		}
+		if ( 200 !== $readme_resp['code'] ) {
+			$readme_resp = $this->fetcher->fetch_raw( "{$prefix}readme.md" );
+		}
+		if ( 200 !== $readme_resp['code'] ) {
+			$readme_resp = $this->fetcher->fetch_raw( "{$prefix}README.md" );
+		}
+
+		return $readme_resp;
+	}
+
+	/**
+	 * Build the report meta array.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param array<string, mixed> $readme_data   Parsed trunk readme data.
+	 * @param string|null          $plugin_file   Main plugin PHP filename.
+	 * @param string|null          $stable_tag    Stable tag from trunk/readme.txt.
+	 * @param string|null          $trunk_version Version from trunk PHP header.
+	 * @return array<string, mixed>
+	 */
+	private function build_meta( array $readme_data, ?string $plugin_file, ?string $stable_tag, ?string $trunk_version ): array {
+		return array(
+			'plugin_name'   => $readme_data['name'] ?? null,
+			'plugin_file'   => $plugin_file,
+			'stable_tag'    => $stable_tag,
+			'trunk_version' => $trunk_version,
+			'requires_php'  => $readme_data['requires_php'] ?? null,
+			'tested_up_to'  => $readme_data['tested_up_to'] ?? null,
+			'svn_url'       => $this->base_url,
+		);
+	}
+
+	/**
+	 * Build the root section (no additional requests).
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param bool $tags_exists   Whether tags/ exists.
+	 * @param bool $assets_exists Whether assets/ exists.
+	 * @return Section
+	 */
+	private function build_root_section( bool $tags_exists, bool $assets_exists ): Section {
+		$root_section = new Section( 'root', __( 'Main SVN Folder', 'plugin-check' ) );
+		$root_section->add_check( 'root_trunk_exists', __( 'trunk/ exists', 'plugin-check' ), 'pass', __( 'Found', 'plugin-check' ) );
+		$root_section->add_check( 'root_tags_exists', __( 'tags/ exists', 'plugin-check' ), $tags_exists ? 'pass' : 'fail', $tags_exists ? __( 'Found', 'plugin-check' ) : __( 'Missing', 'plugin-check' ) );
+		$root_section->add_check( 'root_assets_exists', __( 'assets/ exists', 'plugin-check' ), $assets_exists ? 'pass' : 'warn', $assets_exists ? __( 'Found', 'plugin-check' ) : __( 'Missing — optional but recommended', 'plugin-check' ) );
+
+		return $root_section;
+	}
+
+	/**
+	 * Build the trunk section (no additional requests).
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param bool        $readme_ok     Whether a trunk readme was found.
+	 * @param string|null $stable_tag    Stable tag from trunk/readme.txt.
+	 * @param string|null $plugin_file   Main plugin PHP filename.
+	 * @param string|null $trunk_version Version from trunk PHP header.
+	 * @return Section
+	 */
+	private function build_trunk_section( bool $readme_ok, ?string $stable_tag, ?string $plugin_file, ?string $trunk_version ): Section {
+		$trunk_section = new Section( 'trunk', __( 'Trunk', 'plugin-check' ) );
+
+		$this->add_trunk_readme_check( $trunk_section, $readme_ok );
+		$this->add_trunk_stable_tag_check( $trunk_section, $stable_tag );
+		$this->add_trunk_main_php_check( $trunk_section, $plugin_file );
+		$this->add_trunk_version_check( $trunk_section, $trunk_version, $plugin_file );
+		$this->add_trunk_version_match_check( $trunk_section, $stable_tag, $trunk_version );
+
+		return $trunk_section;
+	}
+
+	/**
+	 * Add the trunk_readme_found check.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param Section $section    Section to add the check to.
+	 * @param bool    $readme_ok  Whether a trunk readme was found.
+	 */
+	private function add_trunk_readme_check( Section $section, bool $readme_ok ): void {
+		$section->add_check(
+			'trunk_readme_found',
+			__( 'readme.txt found', 'plugin-check' ),
+			$readme_ok ? 'pass' : 'fail',
+			$readme_ok
+				? 'trunk/readme.txt'
+				/* translators: %s: file path. */
+				: sprintf( __( '%s is missing', 'plugin-check' ), 'trunk/readme.txt' )
+		);
+	}
+
+	/**
+	 * Add the trunk_stable_tag_declared check.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param Section     $section    Section to add the check to.
+	 * @param string|null $stable_tag Stable tag from trunk/readme.txt.
+	 */
+	private function add_trunk_stable_tag_check( Section $section, ?string $stable_tag ): void {
+		$section->add_check(
+			'trunk_stable_tag_declared',
+			__( 'Stable tag declared', 'plugin-check' ),
+			! empty( $stable_tag ) ? 'pass' : 'fail',
+			! empty( $stable_tag )
+				? $stable_tag
+				/* translators: %s: file path. */
+				: sprintf( __( '"Stable tag:" not found in %s', 'plugin-check' ), 'trunk/readme.txt' )
+		);
+	}
+
+	/**
+	 * Add the trunk_main_php_file_found check.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param Section     $section     Section to add the check to.
+	 * @param string|null $plugin_file Main plugin PHP filename.
+	 */
+	private function add_trunk_main_php_check( Section $section, ?string $plugin_file ): void {
+		$section->add_check(
+			'trunk_main_php_file_found',
+			__( 'Main plugin PHP file found', 'plugin-check' ),
+			! empty( $plugin_file ) ? 'pass' : 'warn',
+			! empty( $plugin_file ) ? "trunk/{$plugin_file}" : __( 'No PHP file with "Plugin Name:" header found in trunk/', 'plugin-check' )
+		);
+	}
+
+	/**
+	 * Add the trunk_version_declared check.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param Section     $section       Section to add the check to.
+	 * @param string|null $trunk_version Version from trunk PHP header.
+	 * @param string|null $plugin_file   Main plugin PHP filename.
+	 */
+	private function add_trunk_version_check( Section $section, ?string $trunk_version, ?string $plugin_file ): void {
+		if ( ! empty( $trunk_version ) ) {
+			$section->add_check( 'trunk_version_declared', __( 'Version declared in PHP header', 'plugin-check' ), 'pass', $trunk_version );
+			return;
+		}
+
+		if ( $plugin_file ) {
+			/* translators: %s: file name. */
+			$message = sprintf( __( 'No "Version:" header in trunk/%s', 'plugin-check' ), $plugin_file );
+			$section->add_check( 'trunk_version_declared', __( 'Version declared in PHP header', 'plugin-check' ), 'fail', $message );
+			return;
+		}
+
+		$section->add_check( 'trunk_version_declared', __( 'Version declared in PHP header', 'plugin-check' ), 'warn', __( 'Skipped — plugin PHP file not found', 'plugin-check' ) );
+	}
+
+	/**
+	 * Add the trunk_stable_tag_matches_version check.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param Section     $section       Section to add the check to.
+	 * @param string|null $stable_tag    Stable tag from trunk/readme.txt.
 	 * @param string|null $trunk_version Version from trunk PHP header.
 	 */
-	private function add_stable_tag_checks(
-		Section $section,
-		string $tag,
-		string $plugin_file,
-		?string $trunk_stable,
-		?string $trunk_version
-	): void {
-		// Attempt readme.txt, then README.txt, readme.md, README.md in tag.
-		$readme_resp = $this->fetcher->fetch_raw( "tags/{$tag}/readme.txt" );
-		if ( 200 !== $readme_resp['code'] ) {
-			$readme_resp = $this->fetcher->fetch_raw( "tags/{$tag}/README.txt" );
+	private function add_trunk_version_match_check( Section $section, ?string $stable_tag, ?string $trunk_version ): void {
+		if ( empty( $stable_tag ) || empty( $trunk_version ) ) {
+			$section->add_check( 'trunk_stable_tag_matches_version', __( 'Stable tag matches PHP version', 'plugin-check' ), 'warn', __( 'Cannot compare — one or both values missing', 'plugin-check' ) );
+			return;
 		}
-		if ( 200 !== $readme_resp['code'] ) {
-			$readme_resp = $this->fetcher->fetch_raw( "tags/{$tag}/readme.md" );
+
+		$match = ( $stable_tag === $trunk_version );
+		$section->add_check(
+			'trunk_stable_tag_matches_version',
+			__( 'Stable tag matches PHP version', 'plugin-check' ),
+			$match ? 'pass' : 'fail',
+			$match ? "{$stable_tag} === {$trunk_version}" : "readme={$stable_tag}, php={$trunk_version}"
+		);
+	}
+
+	/**
+	 * Build the stable_tag section, or null if there is no stable tag to check.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param string|null $stable_tag    Stable tag from trunk/readme.txt.
+	 * @param string|null $plugin_file   Main plugin PHP filename.
+	 * @param string|null $trunk_version Version from trunk PHP header.
+	 * @return Section|null
+	 */
+	private function build_stable_tag_section( ?string $stable_tag, ?string $plugin_file, ?string $trunk_version ): ?Section {
+		if ( ! $stable_tag ) {
+			return null;
 		}
-		if ( 200 !== $readme_resp['code'] ) {
-			$readme_resp = $this->fetcher->fetch_raw( "tags/{$tag}/README.md" );
+
+		$stable_tag_section = new Section( 'stable_tag', "tags/{$stable_tag}/" );
+
+		$tag_exists = 200 === $this->fetcher->fetch_raw( "tags/{$stable_tag}/" )['code'];
+		$stable_tag_section->add_check(
+			'stable_tag_dir_exists',
+			/* translators: %s: SVN tag directory path. */
+			sprintf( __( '%s exists', 'plugin-check' ), "tags/{$stable_tag}/" ),
+			$tag_exists ? 'pass' : 'fail',
+			$tag_exists
+				? __( 'Found', 'plugin-check' )
+				/* translators: %s: SVN tag directory path. */
+				: sprintf( __( '%s not found', 'plugin-check' ), "tags/{$stable_tag}/" )
+		);
+
+		if ( $tag_exists && $plugin_file ) {
+			$this->add_tag_readme_checks( $stable_tag_section, $stable_tag, $stable_tag );
+			$this->add_tag_php_checks( $stable_tag_section, $stable_tag, $plugin_file, $trunk_version );
 		}
-		$readme_ok = 200 === $readme_resp['code'];
+
+		return $stable_tag_section;
+	}
+
+	/**
+	 * Add readme-related checks for the tags/{tag}/ folder.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param Section     $section      Section to add checks to.
+	 * @param string      $tag          Stable tag version string.
+	 * @param string|null $trunk_stable Stable tag from trunk/readme.txt.
+	 */
+	private function add_tag_readme_checks( Section $section, string $tag, ?string $trunk_stable ): void {
+		$readme_resp = $this->fetch_readme_fallback( "tags/{$tag}/" );
+		$readme_ok   = 200 === $readme_resp['code'];
 
 		$section->add_check(
 			'tag_readme_found',
@@ -268,29 +381,42 @@ class Checker {
 				: sprintf( __( '%s is missing', 'plugin-check' ), "tags/{$tag}/readme.txt" )
 		);
 
-		if ( $readme_ok ) {
-			$readme_data = $this->fetcher->parse_readme( $readme_resp['body'] );
-			$tag_stable  = $readme_data['stable_tag'] ?? null;
-
-			$section->add_check(
-				'tag_stable_tag_declared',
-				__( 'Stable tag declared', 'plugin-check' ),
-				! empty( $tag_stable ) ? 'pass' : 'fail',
-				! empty( $tag_stable ) ? $tag_stable : __( '"Stable tag:" not found', 'plugin-check' )
-			);
-
-			if ( $trunk_stable && $tag_stable ) {
-				$match = ( $tag_stable === $trunk_stable );
-				$section->add_check(
-					'tag_readme_stable_tag_matches_trunk',
-					__( 'readme stable tag matches trunk', 'plugin-check' ),
-					$match ? 'pass' : 'fail',
-					"{$tag_stable} === {$trunk_stable}"
-				);
-			}
+		if ( ! $readme_ok ) {
+			return;
 		}
 
-		// Plugin PHP file in tag.
+		$readme_data = $this->fetcher->parse_readme( $readme_resp['body'] );
+		$tag_stable  = $readme_data['stable_tag'] ?? null;
+
+		$section->add_check(
+			'tag_stable_tag_declared',
+			__( 'Stable tag declared', 'plugin-check' ),
+			! empty( $tag_stable ) ? 'pass' : 'fail',
+			! empty( $tag_stable ) ? $tag_stable : __( '"Stable tag:" not found', 'plugin-check' )
+		);
+
+		if ( $trunk_stable && $tag_stable ) {
+			$match = ( $tag_stable === $trunk_stable );
+			$section->add_check(
+				'tag_readme_stable_tag_matches_trunk',
+				__( 'readme stable tag matches trunk', 'plugin-check' ),
+				$match ? 'pass' : 'fail',
+				"{$tag_stable} === {$trunk_stable}"
+			);
+		}
+	}
+
+	/**
+	 * Add PHP-header-related checks for the tags/{tag}/ folder.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param Section     $section       Section to add checks to.
+	 * @param string      $tag           Stable tag version string.
+	 * @param string      $plugin_file   Main plugin PHP filename.
+	 * @param string|null $trunk_version Version from trunk PHP header.
+	 */
+	private function add_tag_php_checks( Section $section, string $tag, string $plugin_file, ?string $trunk_version ): void {
 		$php_resp = $this->fetcher->fetch_raw( "tags/{$tag}/{$plugin_file}" );
 		$php_ok   = 200 === $php_resp['code'];
 
@@ -304,26 +430,28 @@ class Checker {
 				: sprintf( __( '%s is missing', 'plugin-check' ), "tags/{$tag}/{$plugin_file}" )
 		);
 
-		if ( $php_ok ) {
-			$php_data    = $this->fetcher->parse_plugin_headers( $php_resp['body'] );
-			$php_version = $php_data['Version'] ?? null;
+		if ( ! $php_ok ) {
+			return;
+		}
 
+		$php_data    = $this->fetcher->parse_plugin_headers( $php_resp['body'] );
+		$php_version = $php_data['Version'] ?? null;
+
+		$section->add_check(
+			'tag_version_declared',
+			__( 'Version declared', 'plugin-check' ),
+			! empty( $php_version ) ? 'pass' : 'fail',
+			! empty( $php_version ) ? $php_version : __( '"Version:" header not found', 'plugin-check' )
+		);
+
+		if ( $trunk_version && $php_version ) {
+			$match = ( $php_version === $trunk_version );
 			$section->add_check(
-				'tag_version_declared',
-				__( 'Version declared', 'plugin-check' ),
-				! empty( $php_version ) ? 'pass' : 'fail',
-				! empty( $php_version ) ? $php_version : __( '"Version:" header not found', 'plugin-check' )
+				'tag_php_version_matches_trunk',
+				__( 'PHP version matches trunk', 'plugin-check' ),
+				$match ? 'pass' : 'fail',
+				"{$php_version} === {$trunk_version}"
 			);
-
-			if ( $trunk_version && $php_version ) {
-				$match = ( $php_version === $trunk_version );
-				$section->add_check(
-					'tag_php_version_matches_trunk',
-					__( 'PHP version matches trunk', 'plugin-check' ),
-					$match ? 'pass' : 'fail',
-					"{$php_version} === {$trunk_version}"
-				);
-			}
 		}
 	}
 

--- a/includes/SVN/Checker.php
+++ b/includes/SVN/Checker.php
@@ -184,7 +184,7 @@ class Checker {
 	 * @return Section
 	 */
 	private function build_root_section( bool $tags_exists, bool $assets_exists ): Section {
-		$root_section = new Section( 'root', __( 'Main SVN Folder', 'plugin-check' ) );
+		$root_section = new Section( 'root', __( 'Root', 'plugin-check' ) );
 		$root_section->add_check( 'root_trunk_exists', __( 'trunk/ exists', 'plugin-check' ), 'pass', __( 'Found', 'plugin-check' ) );
 		$root_section->add_check( 'root_tags_exists', __( 'tags/ exists', 'plugin-check' ), $tags_exists ? 'pass' : 'fail', $tags_exists ? __( 'Found', 'plugin-check' ) : __( 'Missing', 'plugin-check' ) );
 		$root_section->add_check( 'root_assets_exists', __( 'assets/ exists', 'plugin-check' ), $assets_exists ? 'pass' : 'warn', $assets_exists ? __( 'Found', 'plugin-check' ) : __( 'Missing — optional but recommended', 'plugin-check' ) );

--- a/includes/SVN/Checker.php
+++ b/includes/SVN/Checker.php
@@ -333,6 +333,16 @@ class Checker {
 	 * @param string|null $trunk_version Version from trunk PHP header.
 	 */
 	private function add_trunk_version_match_check( Section $section, ?string $stable_tag, ?string $trunk_version ): void {
+		if ( $this->is_trunk_stable_tag( $stable_tag ) ) {
+			$section->add_check(
+				'trunk_stable_tag_matches_version',
+				__( 'Stable tag matches PHP version', 'plugin-check' ),
+				'pass',
+				__( 'Stable tag is "trunk" — trunk/ is released directly, no version match needed', 'plugin-check' )
+			);
+			return;
+		}
+
 		if ( empty( $stable_tag ) || empty( $trunk_version ) ) {
 			$section->add_check( 'trunk_stable_tag_matches_version', __( 'Stable tag matches PHP version', 'plugin-check' ), 'warn', __( 'Cannot compare — one or both values missing', 'plugin-check' ) );
 			return;
@@ -358,7 +368,7 @@ class Checker {
 	 * @return Section|null
 	 */
 	private function build_stable_tag_section( ?string $stable_tag, ?string $plugin_file, ?string $trunk_version ): ?Section {
-		if ( ! $stable_tag ) {
+		if ( ! $stable_tag || $this->is_trunk_stable_tag( $stable_tag ) ) {
 			return null;
 		}
 
@@ -622,6 +632,21 @@ class Checker {
 				/* translators: %s: file path. */
 				: sprintf( __( '%s not found — optional, needed for "Live Preview"', 'plugin-check' ), 'assets/blueprints/blueprint.json' )
 		);
+	}
+
+	/**
+	 * Check whether the stable tag uses the "trunk" convention.
+	 *
+	 * WordPress.org allows `Stable tag: trunk`, meaning trunk/ itself is released
+	 * directly with no corresponding tags/{version}/ folder.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param string|null $stable_tag Stable tag from trunk/readme.txt.
+	 * @return bool
+	 */
+	private function is_trunk_stable_tag( ?string $stable_tag ): bool {
+		return null !== $stable_tag && 'trunk' === strtolower( $stable_tag );
 	}
 
 	/**

--- a/includes/SVN/Checker.php
+++ b/includes/SVN/Checker.php
@@ -88,6 +88,9 @@ class Checker {
 			);
 		}
 
+		// Fetch the SVN base directory listing for the unexpected-files check.
+		$root_dir = $this->fetcher->fetch_directory( '' );
+
 		// Find main PHP file from the listing; returns content to avoid a second fetch.
 		[ 'file' => $plugin_file, 'content' => $php_content ] =
 			$this->find_main_plugin_file_with_content( $trunk_dir['items'] );
@@ -95,8 +98,9 @@ class Checker {
 			? $this->fetcher->parse_plugin_headers( $php_content )
 			: array();
 
-		// Check tags/ existence only — no need to parse the full listing.
-		$tags_exists = 200 === $this->fetcher->fetch_raw( 'tags/' )['code'];
+		// Fetch tags/ listing for existence check and unexpected-files scan (one request).
+		$tags_dir    = $this->fetcher->fetch_directory( 'tags/' );
+		$tags_exists = $tags_dir['exists'];
 
 		// Fetch assets/ listing for existence check and asset file scan (one request).
 		$assets_dir    = $this->fetcher->fetch_directory( 'assets/' );
@@ -108,8 +112,8 @@ class Checker {
 		$meta = $this->build_meta( $readme_data, $plugin_file, $stable_tag, $trunk_version );
 
 		$sections   = array();
-		$sections[] = $this->build_root_section( $tags_exists, $assets_exists );
-		$sections[] = $this->build_trunk_section( $readme_ok, $stable_tag, $plugin_file, $trunk_version );
+		$sections[] = $this->build_root_section( $root_dir['items'], $tags_dir['items'], $tags_exists, $assets_exists );
+		$sections[] = $this->build_trunk_section( $readme_ok, $stable_tag, $plugin_file, $trunk_version, $trunk_dir['items'] );
 
 		$stable_tag_section = $this->build_stable_tag_section( $stable_tag, $plugin_file, $trunk_version );
 		if ( $stable_tag_section ) {
@@ -179,17 +183,79 @@ class Checker {
 	 *
 	 * @since 2.1.0
 	 *
-	 * @param bool $tags_exists   Whether tags/ exists.
-	 * @param bool $assets_exists Whether assets/ exists.
+	 * @param array<int, array{name: string, href: string, is_dir: bool}> $root_items    Pre-fetched SVN root listing.
+	 * @param array<int, array{name: string, href: string, is_dir: bool}> $tags_items    Pre-fetched tags/ listing.
+	 * @param bool                                                        $tags_exists   Whether tags/ exists.
+	 * @param bool                                                        $assets_exists Whether assets/ exists.
 	 * @return Section
 	 */
-	private function build_root_section( bool $tags_exists, bool $assets_exists ): Section {
+	private function build_root_section( array $root_items, array $tags_items, bool $tags_exists, bool $assets_exists ): Section {
 		$root_section = new Section( 'root', __( 'Root', 'plugin-check' ) );
 		$root_section->add_check( 'root_trunk_exists', __( 'trunk/ exists', 'plugin-check' ), 'pass', __( 'Found', 'plugin-check' ) );
 		$root_section->add_check( 'root_tags_exists', __( 'tags/ exists', 'plugin-check' ), $tags_exists ? 'pass' : 'fail', $tags_exists ? __( 'Found', 'plugin-check' ) : __( 'Missing', 'plugin-check' ) );
 		$root_section->add_check( 'root_assets_exists', __( 'assets/ exists', 'plugin-check' ), $assets_exists ? 'pass' : 'warn', $assets_exists ? __( 'Found', 'plugin-check' ) : __( 'Missing — optional but recommended', 'plugin-check' ) );
 
+		$this->add_root_unexpected_files_check( $root_section, $root_items );
+		$this->add_root_tags_unexpected_files_check( $root_section, $tags_items );
+
 		return $root_section;
+	}
+
+	/**
+	 * Add the root_unexpected_files check.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param Section                                                     $section    Section to add the check to.
+	 * @param array<int, array{name: string, href: string, is_dir: bool}> $root_items Pre-fetched SVN root listing.
+	 */
+	private function add_root_unexpected_files_check( Section $section, array $root_items ): void {
+		$allowed    = array( 'assets', 'branches', 'tags', 'trunk' );
+		$unexpected = array();
+
+		foreach ( $root_items as $item ) {
+			if ( ! in_array( $item['name'], $allowed, true ) ) {
+				$unexpected[] = $item['name'];
+			}
+		}
+
+		$section->add_check(
+			'root_unexpected_files',
+			__( 'No unexpected files in SVN root', 'plugin-check' ),
+			empty( $unexpected ) ? 'pass' : 'fail',
+			empty( $unexpected )
+				? __( 'None found', 'plugin-check' )
+				/* translators: %s: comma-separated list of file/directory names. */
+				: sprintf( __( 'Unexpected: %s', 'plugin-check' ), implode( ', ', $unexpected ) )
+		);
+	}
+
+	/**
+	 * Add the root_tags_unexpected_files check.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param Section                                                     $section    Section to add the check to.
+	 * @param array<int, array{name: string, href: string, is_dir: bool}> $tags_items Pre-fetched tags/ listing.
+	 */
+	private function add_root_tags_unexpected_files_check( Section $section, array $tags_items ): void {
+		$unexpected = array();
+
+		foreach ( $tags_items as $item ) {
+			if ( ! $item['is_dir'] ) {
+				$unexpected[] = $item['name'];
+			}
+		}
+
+		$section->add_check(
+			'root_tags_unexpected_files',
+			__( 'No unexpected files in tags/', 'plugin-check' ),
+			empty( $unexpected ) ? 'pass' : 'fail',
+			empty( $unexpected )
+				? __( 'None found', 'plugin-check' )
+				/* translators: %s: comma-separated list of file names. */
+				: sprintf( __( 'Unexpected in tags/: %s', 'plugin-check' ), implode( ', ', $unexpected ) )
+		);
 	}
 
 	/**
@@ -197,13 +263,14 @@ class Checker {
 	 *
 	 * @since 2.1.0
 	 *
-	 * @param bool        $readme_ok     Whether a trunk readme was found.
-	 * @param string|null $stable_tag    Stable tag from trunk/readme.txt.
-	 * @param string|null $plugin_file   Main plugin PHP filename.
-	 * @param string|null $trunk_version Version from trunk PHP header.
+	 * @param bool                                                        $readme_ok     Whether a trunk readme was found.
+	 * @param string|null                                                 $stable_tag    Stable tag from trunk/readme.txt.
+	 * @param string|null                                                 $plugin_file   Main plugin PHP filename.
+	 * @param string|null                                                 $trunk_version Version from trunk PHP header.
+	 * @param array<int, array{name: string, href: string, is_dir: bool}> $trunk_items   Pre-fetched trunk/ listing.
 	 * @return Section
 	 */
-	private function build_trunk_section( bool $readme_ok, ?string $stable_tag, ?string $plugin_file, ?string $trunk_version ): Section {
+	private function build_trunk_section( bool $readme_ok, ?string $stable_tag, ?string $plugin_file, ?string $trunk_version, array $trunk_items ): Section {
 		$trunk_section = new Section( 'trunk', __( 'Trunk', 'plugin-check' ) );
 
 		$this->add_trunk_readme_check( $trunk_section, $readme_ok );
@@ -211,8 +278,31 @@ class Checker {
 		$this->add_trunk_main_php_check( $trunk_section, $plugin_file );
 		$this->add_trunk_version_check( $trunk_section, $trunk_version, $plugin_file );
 		$this->add_trunk_version_match_check( $trunk_section, $stable_tag, $trunk_version );
+		$this->add_trunk_unexpected_files_check( $trunk_section, $trunk_items );
 
 		return $trunk_section;
+	}
+
+	/**
+	 * Add the trunk_unexpected_files check.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param Section                                                     $section     Section to add the check to.
+	 * @param array<int, array{name: string, href: string, is_dir: bool}> $trunk_items Pre-fetched trunk/ listing.
+	 */
+	private function add_trunk_unexpected_files_check( Section $section, array $trunk_items ): void {
+		$unexpected = $this->find_files_with_extensions( $trunk_items, array( 'zip' ) );
+
+		$section->add_check(
+			'trunk_unexpected_files',
+			__( 'No unexpected files in trunk/', 'plugin-check' ),
+			empty( $unexpected ) ? 'pass' : 'fail',
+			empty( $unexpected )
+				? __( 'None found', 'plugin-check' )
+				/* translators: %s: comma-separated list of file names. */
+				: sprintf( __( 'Unexpected in trunk/: %s', 'plugin-check' ), implode( ', ', $unexpected ) )
+		);
 	}
 
 	/**
@@ -338,7 +428,8 @@ class Checker {
 
 		$stable_tag_section = new Section( 'stable_tag', "tags/{$stable_tag}/" );
 
-		$tag_exists = 200 === $this->fetcher->fetch_raw( "tags/{$stable_tag}/" )['code'];
+		$tag_dir    = $this->fetcher->fetch_directory( "tags/{$stable_tag}/" );
+		$tag_exists = $tag_dir['exists'];
 		$stable_tag_section->add_check(
 			'stable_tag_dir_exists',
 			/* translators: %s: SVN tag directory path. */
@@ -350,12 +441,38 @@ class Checker {
 				: sprintf( __( '%s not found', 'plugin-check' ), "tags/{$stable_tag}/" )
 		);
 
-		if ( $tag_exists && $plugin_file ) {
-			$this->add_tag_readme_checks( $stable_tag_section, $stable_tag, $stable_tag );
-			$this->add_tag_php_checks( $stable_tag_section, $stable_tag, $plugin_file, $trunk_version );
+		if ( $tag_exists ) {
+			$this->add_tag_unexpected_files_check( $stable_tag_section, $tag_dir['items'] );
+
+			if ( $plugin_file ) {
+				$this->add_tag_readme_checks( $stable_tag_section, $stable_tag, $stable_tag );
+				$this->add_tag_php_checks( $stable_tag_section, $stable_tag, $plugin_file, $trunk_version );
+			}
 		}
 
 		return $stable_tag_section;
+	}
+
+	/**
+	 * Add the tag_unexpected_files check.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param Section                                                     $section   Section to add the check to.
+	 * @param array<int, array{name: string, href: string, is_dir: bool}> $tag_items Pre-fetched tags/{tag}/ listing.
+	 */
+	private function add_tag_unexpected_files_check( Section $section, array $tag_items ): void {
+		$unexpected = $this->find_files_with_extensions( $tag_items, array( 'zip' ) );
+
+		$section->add_check(
+			'tag_unexpected_files',
+			__( 'No unexpected files', 'plugin-check' ),
+			empty( $unexpected ) ? 'pass' : 'fail',
+			empty( $unexpected )
+				? __( 'None found', 'plugin-check' )
+				/* translators: %s: comma-separated list of file names. */
+				: sprintf( __( 'Unexpected: %s', 'plugin-check' ), implode( ', ', $unexpected ) )
+		);
 	}
 
 	/**
@@ -493,6 +610,108 @@ class Checker {
 			/* translators: %s: file name pattern. */
 			$icon_file ?? sprintf( __( '%s not found — optional', 'plugin-check' ), 'icon-128x128.(png|jpg) or icon.svg' )
 		);
+
+		$this->add_assets_unexpected_files_check( $section, $items );
+		$this->add_assets_blueprint_check( $section, $items );
+	}
+
+	/**
+	 * Add the assets_unexpected_files check.
+	 *
+	 * Allowed: image files (jpg, png, svg, gif) and the optional blueprints/ folder.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param Section                                                     $section Section to add the check to.
+	 * @param array<int, array{name: string, href: string, is_dir: bool}> $items   Pre-fetched assets/ listing.
+	 */
+	private function add_assets_unexpected_files_check( Section $section, array $items ): void {
+		$allowed_extensions = array( 'jpg', 'png', 'svg', 'gif' );
+		$unexpected         = array();
+
+		foreach ( $items as $item ) {
+			if ( $item['is_dir'] ) {
+				if ( 'blueprints' !== strtolower( $item['name'] ) ) {
+					$unexpected[] = $item['name'];
+				}
+				continue;
+			}
+
+			$extension = strtolower( pathinfo( $item['name'], PATHINFO_EXTENSION ) );
+			if ( ! in_array( $extension, $allowed_extensions, true ) ) {
+				$unexpected[] = $item['name'];
+			}
+		}
+
+		$section->add_check(
+			'assets_unexpected_files',
+			__( 'No unexpected files', 'plugin-check' ),
+			empty( $unexpected ) ? 'pass' : 'fail',
+			empty( $unexpected )
+				? __( 'None found', 'plugin-check' )
+				/* translators: %s: comma-separated list of file/directory names. */
+				: sprintf( __( 'Unexpected: %s', 'plugin-check' ), implode( ', ', $unexpected ) )
+		);
+	}
+
+	/**
+	 * Add the assets_blueprint_present check, if a blueprints/ folder exists.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param Section                                                     $section Section to add the check to.
+	 * @param array<int, array{name: string, href: string, is_dir: bool}> $items   Pre-fetched assets/ listing.
+	 */
+	private function add_assets_blueprint_check( Section $section, array $items ): void {
+		$has_blueprints_dir = false;
+		foreach ( $items as $item ) {
+			if ( $item['is_dir'] && 'blueprints' === strtolower( $item['name'] ) ) {
+				$has_blueprints_dir = true;
+				break;
+			}
+		}
+
+		if ( ! $has_blueprints_dir ) {
+			return;
+		}
+
+		$blueprint_ok = 200 === $this->fetcher->fetch_raw( 'assets/blueprints/blueprint.json' )['code'];
+
+		$section->add_check(
+			'assets_blueprint_present',
+			__( 'Blueprint file present', 'plugin-check' ),
+			$blueprint_ok ? 'pass' : 'info',
+			$blueprint_ok
+				? 'assets/blueprints/blueprint.json'
+				/* translators: %s: file path. */
+				: sprintf( __( '%s not found — optional, needed for "Live Preview"', 'plugin-check' ), 'assets/blueprints/blueprint.json' )
+		);
+	}
+
+	/**
+	 * Find files (not directories) in a listing matching one of the given extensions.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param array<int, array{name: string, href: string, is_dir: bool}> $items      Directory listing items.
+	 * @param array<int, string>                                          $extensions Extensions to match (lowercase, no dot).
+	 * @return array<int, string> Matching file names.
+	 */
+	private function find_files_with_extensions( array $items, array $extensions ): array {
+		$matches = array();
+
+		foreach ( $items as $item ) {
+			if ( $item['is_dir'] ) {
+				continue;
+			}
+
+			$extension = strtolower( pathinfo( $item['name'], PATHINFO_EXTENSION ) );
+			if ( in_array( $extension, $extensions, true ) ) {
+				$matches[] = $item['name'];
+			}
+		}
+
+		return $matches;
 	}
 
 	/**

--- a/includes/SVN/Checker.php
+++ b/includes/SVN/Checker.php
@@ -18,6 +18,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * structured report data.
  *
  * @since 2.1.0
+ *
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  */
 class Checker {
 

--- a/includes/SVN/Checker.php
+++ b/includes/SVN/Checker.php
@@ -90,9 +90,6 @@ class Checker {
 			);
 		}
 
-		// Fetch the SVN base directory listing for the unexpected-files check.
-		$root_dir = $this->fetcher->fetch_directory( '' );
-
 		// Find main PHP file from the listing; returns content to avoid a second fetch.
 		[ 'file' => $plugin_file, 'content' => $php_content ] =
 			$this->find_main_plugin_file_with_content( $trunk_dir['items'] );
@@ -100,9 +97,8 @@ class Checker {
 			? $this->fetcher->parse_plugin_headers( $php_content )
 			: array();
 
-		// Fetch tags/ listing for existence check and unexpected-files scan (one request).
-		$tags_dir    = $this->fetcher->fetch_directory( 'tags/' );
-		$tags_exists = $tags_dir['exists'];
+		// Check tags/ existence only — no need to parse the full listing.
+		$tags_exists = 200 === $this->fetcher->fetch_raw( 'tags/' )['code'];
 
 		// Fetch assets/ listing for existence check and asset file scan (one request).
 		$assets_dir    = $this->fetcher->fetch_directory( 'assets/' );
@@ -114,7 +110,7 @@ class Checker {
 		$meta = $this->build_meta( $readme_data, $plugin_file, $stable_tag, $trunk_version );
 
 		$sections   = array();
-		$sections[] = $this->build_root_section( $root_dir['items'], $tags_dir['items'], $tags_exists, $assets_exists );
+		$sections[] = $this->build_root_section( $tags_exists, $assets_exists );
 		$sections[] = $this->build_trunk_section( $readme_ok, $stable_tag, $plugin_file, $trunk_version, $trunk_dir['items'] );
 
 		$stable_tag_section = $this->build_stable_tag_section( $stable_tag, $plugin_file, $trunk_version );
@@ -185,79 +181,17 @@ class Checker {
 	 *
 	 * @since 2.1.0
 	 *
-	 * @param array<int, array{name: string, href: string, is_dir: bool}> $root_items    Pre-fetched SVN root listing.
-	 * @param array<int, array{name: string, href: string, is_dir: bool}> $tags_items    Pre-fetched tags/ listing.
-	 * @param bool                                                        $tags_exists   Whether tags/ exists.
-	 * @param bool                                                        $assets_exists Whether assets/ exists.
+	 * @param bool $tags_exists   Whether tags/ exists.
+	 * @param bool $assets_exists Whether assets/ exists.
 	 * @return Section
 	 */
-	private function build_root_section( array $root_items, array $tags_items, bool $tags_exists, bool $assets_exists ): Section {
+	private function build_root_section( bool $tags_exists, bool $assets_exists ): Section {
 		$root_section = new Section( 'root', __( 'Root', 'plugin-check' ) );
 		$root_section->add_check( 'root_trunk_exists', __( 'trunk/ exists', 'plugin-check' ), 'pass', __( 'Found', 'plugin-check' ) );
 		$root_section->add_check( 'root_tags_exists', __( 'tags/ exists', 'plugin-check' ), $tags_exists ? 'pass' : 'fail', $tags_exists ? __( 'Found', 'plugin-check' ) : __( 'Missing', 'plugin-check' ) );
 		$root_section->add_check( 'root_assets_exists', __( 'assets/ exists', 'plugin-check' ), $assets_exists ? 'pass' : 'warn', $assets_exists ? __( 'Found', 'plugin-check' ) : __( 'Missing — optional but recommended', 'plugin-check' ) );
 
-		$this->add_root_unexpected_files_check( $root_section, $root_items );
-		$this->add_root_tags_unexpected_files_check( $root_section, $tags_items );
-
 		return $root_section;
-	}
-
-	/**
-	 * Add the root_unexpected_files check.
-	 *
-	 * @since 2.1.0
-	 *
-	 * @param Section                                                     $section    Section to add the check to.
-	 * @param array<int, array{name: string, href: string, is_dir: bool}> $root_items Pre-fetched SVN root listing.
-	 */
-	private function add_root_unexpected_files_check( Section $section, array $root_items ): void {
-		$allowed    = array( 'assets', 'branches', 'tags', 'trunk' );
-		$unexpected = array();
-
-		foreach ( $root_items as $item ) {
-			if ( ! in_array( $item['name'], $allowed, true ) ) {
-				$unexpected[] = $item['name'];
-			}
-		}
-
-		$section->add_check(
-			'root_unexpected_files',
-			__( 'No unexpected files in SVN root', 'plugin-check' ),
-			empty( $unexpected ) ? 'pass' : 'fail',
-			empty( $unexpected )
-				? __( 'None found', 'plugin-check' )
-				/* translators: %s: comma-separated list of file/directory names. */
-				: sprintf( __( 'Unexpected: %s', 'plugin-check' ), implode( ', ', $unexpected ) )
-		);
-	}
-
-	/**
-	 * Add the root_tags_unexpected_files check.
-	 *
-	 * @since 2.1.0
-	 *
-	 * @param Section                                                     $section    Section to add the check to.
-	 * @param array<int, array{name: string, href: string, is_dir: bool}> $tags_items Pre-fetched tags/ listing.
-	 */
-	private function add_root_tags_unexpected_files_check( Section $section, array $tags_items ): void {
-		$unexpected = array();
-
-		foreach ( $tags_items as $item ) {
-			if ( ! $item['is_dir'] ) {
-				$unexpected[] = $item['name'];
-			}
-		}
-
-		$section->add_check(
-			'root_tags_unexpected_files',
-			__( 'No unexpected files in tags/', 'plugin-check' ),
-			empty( $unexpected ) ? 'pass' : 'fail',
-			empty( $unexpected )
-				? __( 'None found', 'plugin-check' )
-				/* translators: %s: comma-separated list of file names. */
-				: sprintf( __( 'Unexpected in tags/: %s', 'plugin-check' ), implode( ', ', $unexpected ) )
-		);
 	}
 
 	/**
@@ -299,7 +233,7 @@ class Checker {
 		$section->add_check(
 			'trunk_unexpected_files',
 			__( 'No unexpected files in trunk/', 'plugin-check' ),
-			empty( $unexpected ) ? 'pass' : 'fail',
+			empty( $unexpected ) ? 'pass' : 'warn',
 			empty( $unexpected )
 				? __( 'None found', 'plugin-check' )
 				/* translators: %s: comma-separated list of file names. */
@@ -469,7 +403,7 @@ class Checker {
 		$section->add_check(
 			'tag_unexpected_files',
 			__( 'No unexpected files', 'plugin-check' ),
-			empty( $unexpected ) ? 'pass' : 'fail',
+			empty( $unexpected ) ? 'pass' : 'warn',
 			empty( $unexpected )
 				? __( 'None found', 'plugin-check' )
 				/* translators: %s: comma-separated list of file names. */
@@ -648,7 +582,7 @@ class Checker {
 		$section->add_check(
 			'assets_unexpected_files',
 			__( 'No unexpected files', 'plugin-check' ),
-			empty( $unexpected ) ? 'pass' : 'fail',
+			empty( $unexpected ) ? 'pass' : 'warn',
 			empty( $unexpected )
 				? __( 'None found', 'plugin-check' )
 				/* translators: %s: comma-separated list of file/directory names. */

--- a/includes/SVN/Fetcher.php
+++ b/includes/SVN/Fetcher.php
@@ -113,7 +113,7 @@ class Fetcher {
 
 		foreach ( $doc->getElementsByTagName( 'a' ) as $link ) {
 			$href = $link->getAttribute( 'href' );
-			$text = trim( $link->textContent );
+			$text = trim( $link->textContent ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 			if (
 				empty( $href )

--- a/includes/SVN/Fetcher.php
+++ b/includes/SVN/Fetcher.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * Fetcher class.
+ *
+ * @package Plugin_Check
+ */
+
+namespace WordPress\Plugin_Check\SVN;
+
+use DOMDocument;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Fetcher.
+ *
+ * HTTP fetch helpers and file parsers for a WordPress.org plugin SVN repo.
+ *
+ * @since 2.1.0
+ */
+class Fetcher {
+
+	/**
+	 * Trailing-slash base URL of the plugin SVN repo.
+	 *
+	 * @var string
+	 */
+	private string $base_url;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param string $base_url Trailing-slash base URL.
+	 */
+	public function __construct( string $base_url ) {
+		$this->base_url = $base_url;
+	}
+
+	/**
+	 * Fetch a file by relative path. Returns HTTP code and body.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param string $relative_path Path relative to base URL.
+	 * @return array{code: int, body: string}
+	 */
+	public function fetch_raw( string $relative_path ): array {
+		$url      = $this->base_url . ltrim( $relative_path, '/' );
+		$response = wp_remote_get( $url, array( 'timeout' => 20 ) );
+
+		if ( is_wp_error( $response ) ) {
+			return array(
+				'code' => 0,
+				'body' => '',
+			);
+		}
+
+		return array(
+			'code' => (int) wp_remote_retrieve_response_code( $response ),
+			'body' => wp_remote_retrieve_body( $response ),
+		);
+	}
+
+	/**
+	 * Fetch a directory and return both existence flag and parsed items.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param string $relative_path Directory path relative to base URL.
+	 * @return array{exists: bool, items: array<int, array{name: string, href: string, is_dir: bool}>}
+	 */
+	public function fetch_directory( string $relative_path ): array {
+		$r = $this->fetch_raw( $relative_path );
+
+		return array(
+			'exists' => 200 === $r['code'],
+			'items'  => 200 === $r['code'] ? $this->parse_html_links( $r['body'] ) : array(),
+		);
+	}
+
+	/**
+	 * Fetch and parse an SVN HTTP directory listing.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param string $relative_path Directory path relative to base URL.
+	 * @return array<int, array{name: string, href: string, is_dir: bool}>
+	 */
+	public function fetch_directory_items( string $relative_path ): array {
+		return $this->fetch_directory( $relative_path )['items'];
+	}
+
+	/**
+	 * Parse <a> links from an SVN HTML directory listing.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param string $html Raw HTML body.
+	 * @return array<int, array{name: string, href: string, is_dir: bool}>
+	 */
+	private function parse_html_links( string $html ): array {
+		libxml_use_internal_errors( true );
+		$doc = new DOMDocument();
+		$doc->loadHTML( '<?xml encoding="UTF-8">' . $html );
+		libxml_clear_errors();
+
+		$items = array();
+		$seen  = array();
+
+		foreach ( $doc->getElementsByTagName( 'a' ) as $link ) {
+			$href = $link->getAttribute( 'href' );
+			$text = trim( $link->textContent ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+
+			if (
+				empty( $href )
+				|| '../' === $href
+				|| '#' === $href[0]
+				|| '?' === $href[0]
+				|| false !== strpos( $href, '://' )
+				|| isset( $seen[ $href ] )
+			) {
+				continue;
+			}
+
+			$seen[ $href ] = true;
+			$items[]       = array(
+				'name'   => $text ? $text : rtrim( $href, '/' ),
+				'href'   => $href,
+				'is_dir' => '/' === substr( $href, -1 ),
+			);
+		}
+
+		return $items;
+	}
+
+	/**
+	 * Parse readme.txt content into a metadata array.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param string $content Raw readme.txt content.
+	 * @return array<string, string>
+	 */
+	public function parse_readme( string $content ): array {
+		$data   = array();
+		$fields = array(
+			'stable_tag'        => '/^Stable tag:\s*(.+)$/im',
+			'requires_at_least' => '/^Requires at least:\s*(.+)$/im',
+			'tested_up_to'      => '/^Tested up to:\s*(.+)$/im',
+			'requires_php'      => '/^Requires PHP:\s*(.+)$/im',
+		);
+
+		foreach ( $fields as $key => $pattern ) {
+			if ( preg_match( $pattern, $content, $m ) ) {
+				$data[ $key ] = trim( $m[1] );
+			}
+		}
+
+		if ( preg_match( '/^===\s*(.+?)\s*===/m', $content, $m ) ) {
+			$data['name'] = trim( $m[1] );
+		} elseif ( preg_match( '/^#\s+(.+)$/m', $content, $m ) ) {
+			$data['name'] = trim( $m[1] );
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Parse WordPress plugin PHP header fields.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param string $content Raw PHP file content.
+	 * @return array<string, string>
+	 */
+	public function parse_plugin_headers( string $content ): array {
+		$data   = array();
+		$fields = array(
+			'Plugin Name'       => '/^\s*[\/*#]*\s*Plugin Name:\s*(.+)$/im',
+			'Version'           => '/^\s*[\/*#]*\s*Version:\s*(.+)$/im',
+			'Requires at least' => '/^\s*[\/*#]*\s*Requires at least:\s*(.+)$/im',
+			'Tested up to'      => '/^\s*[\/*#]*\s*Tested up to:\s*(.+)$/im',
+			'Requires PHP'      => '/^\s*[\/*#]*\s*Requires PHP:\s*(.+)$/im',
+			'Author'            => '/^\s*[\/*#]*\s*Author:\s*(.+)$/im',
+		);
+
+		foreach ( $fields as $key => $pattern ) {
+			if ( preg_match( $pattern, $content, $m ) ) {
+				$data[ $key ] = trim( $m[1] );
+			}
+		}
+
+		return $data;
+	}
+}

--- a/includes/SVN/Fetcher.php
+++ b/includes/SVN/Fetcher.php
@@ -113,7 +113,7 @@ class Fetcher {
 
 		foreach ( $doc->getElementsByTagName( 'a' ) as $link ) {
 			$href = $link->getAttribute( 'href' );
-			$text = trim( $link->textContent ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			$text = trim( $link->textContent );
 
 			if (
 				empty( $href )
@@ -128,7 +128,7 @@ class Fetcher {
 
 			$seen[ $href ] = true;
 			$items[]       = array(
-				'name'   => $text ? $text : rtrim( $href, '/' ),
+				'name'   => rtrim( $text ? $text : $href, '/' ),
 				'href'   => $href,
 				'is_dir' => '/' === substr( $href, -1 ),
 			);

--- a/includes/SVN/Section.php
+++ b/includes/SVN/Section.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Section class.
+ *
+ * @package Plugin_Check
+ */
+
+namespace WordPress\Plugin_Check\SVN;
+
+use JsonSerializable;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Section.
+ *
+ * A named group of checks within a report.
+ *
+ * @since 2.1.0
+ */
+class Section implements JsonSerializable {
+
+	/**
+	 * Machine-readable section ID.
+	 *
+	 * @var string
+	 */
+	public string $id;
+
+	/**
+	 * Human-readable section label.
+	 *
+	 * @var string
+	 */
+	public string $label;
+
+	/**
+	 * Checks in this section.
+	 *
+	 * @var array<int, array{key: string, label: string, status: string, detail: string}>
+	 */
+	private array $checks = array();
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param string $id    Section ID.
+	 * @param string $label Section label.
+	 */
+	public function __construct( string $id, string $label ) {
+		$this->id    = $id;
+		$this->label = $label;
+	}
+
+	/**
+	 * Add a check.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param string $key    Machine-readable, untranslated check identifier.
+	 * @param string $label  Translated check label.
+	 * @param string $status pass|warn|fail|info.
+	 * @param string $detail Translated detail text.
+	 */
+	public function add_check( string $key, string $label, string $status, string $detail = '' ): void {
+		$this->checks[] = array(
+			'key'    => $key,
+			'label'  => $label,
+			'status' => $status,
+			'detail' => $detail,
+		);
+	}
+
+	/**
+	 * Return checks in this section.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @return array<int, array{key: string, label: string, status: string, detail: string}>
+	 */
+	public function get_checks(): array {
+		return $this->checks;
+	}
+
+	/**
+	 * Serialize to JSON.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function jsonSerialize(): array {
+		return array(
+			'id'     => $this->id,
+			'label'  => $this->label,
+			'checks' => $this->checks,
+		);
+	}
+}

--- a/tests/phpunit/tests/Admin/SVN_Checker_Page_Tests.php
+++ b/tests/phpunit/tests/Admin/SVN_Checker_Page_Tests.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Tests for the SVN_Checker_Page class.
+ *
+ * @package plugin-check
+ */
+
+namespace Admin;
+
+use WordPress\Plugin_Check\Admin\SVN_Checker_Page;
+use WP_UnitTestCase;
+
+class SVN_Checker_Page_Tests extends WP_UnitTestCase {
+
+	protected $svn_checker_page;
+
+	public function set_up() {
+		parent::set_up();
+		$this->svn_checker_page = new SVN_Checker_Page();
+	}
+
+	public function test_add_hooks() {
+		$this->svn_checker_page->add_hooks();
+		$this->assertEquals( 10, has_action( 'admin_menu', array( $this->svn_checker_page, 'add_page' ) ) );
+		$this->assertEquals( 10, has_action( 'admin_enqueue_scripts', array( $this->svn_checker_page, 'enqueue_scripts' ) ) );
+		$this->assertEquals( 10, has_action( 'wp_ajax_' . SVN_Checker_Page::ACTION_CHECK, array( $this->svn_checker_page, 'handle_check' ) ) );
+	}
+
+	public function test_add_page() {
+		global $_parent_pages;
+
+		$current_screen = get_current_screen();
+
+		$admin_user = self::factory()->user->create( array( 'role' => 'administrator' ) );
+
+		if ( is_multisite() ) {
+			grant_super_admin( $admin_user );
+		}
+
+		wp_set_current_user( $admin_user );
+		set_current_screen( 'dashboard' );
+
+		$this->svn_checker_page->add_page();
+		$parent_pages = $_parent_pages;
+
+		set_current_screen( $current_screen );
+
+		$this->assertArrayHasKey( SVN_Checker_Page::MENU_SLUG, $parent_pages );
+		$this->assertEquals( 'tools.php', $parent_pages[ SVN_Checker_Page::MENU_SLUG ] );
+	}
+
+	public function test_render_page() {
+		ob_start();
+		$this->svn_checker_page->render_page();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'plugin-check-svn-checker-form', $output );
+		$this->assertStringContainsString( 'name="plugin_slug"', $output );
+	}
+
+	public function test_render_page_with_slug_from_query_arg() {
+		$_GET['plugin_slug'] = 'hello-dolly';
+
+		ob_start();
+		$this->svn_checker_page->render_page();
+		$output = ob_get_clean();
+
+		unset( $_GET['plugin_slug'] );
+
+		$this->assertStringContainsString( 'value="hello-dolly"', $output );
+	}
+
+	public function test_enqueue_scripts_does_nothing_without_matching_hook() {
+		$this->svn_checker_page->enqueue_scripts( 'some-other-page' );
+
+		$this->assertFalse( wp_style_is( 'plugin-check-svn-checker', 'enqueued' ) );
+		$this->assertFalse( wp_script_is( 'plugin-check-svn-checker', 'enqueued' ) );
+	}
+}

--- a/tests/phpunit/tests/SVN/Checker_Tests.php
+++ b/tests/phpunit/tests/SVN/Checker_Tests.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Tests for the Checker class.
+ *
+ * @package plugin-check
+ */
+
+namespace SVN;
+
+use WordPress\Plugin_Check\SVN\Checker;
+use WordPress\Plugin_Check\SVN\Section;
+use WP_UnitTestCase;
+
+class Checker_Tests extends WP_UnitTestCase {
+
+	/**
+	 * Map of relative SVN path (e.g. 'trunk/readme.txt') to a canned response.
+	 *
+	 * @var array<string, array{code: int, body: string}>
+	 */
+	protected $svn_mock_responses = array();
+
+	public function set_up() {
+		parent::set_up();
+		$this->svn_mock_responses = array();
+		add_filter( 'pre_http_request', array( $this, 'intercept_http_request' ), 10, 3 );
+	}
+
+	public function tear_down() {
+		remove_filter( 'pre_http_request', array( $this, 'intercept_http_request' ) );
+		parent::tear_down();
+	}
+
+	/**
+	 * Intercepts wp_remote_get() calls and returns a canned response based on
+	 * the requested URL's suffix, so no real network request is made.
+	 * Unmocked URLs default to a 404, so a missing stub fails loudly.
+	 */
+	public function intercept_http_request( $preempt, $args, $url ) {
+		foreach ( $this->svn_mock_responses as $relative_path => $response ) {
+			if ( substr( $url, -strlen( $relative_path ) ) === $relative_path ) {
+				return array(
+					'response' => array( 'code' => $response['code'] ),
+					'body'     => $response['body'] ?? '',
+				);
+			}
+		}
+
+		return array(
+			'response' => array( 'code' => 404 ),
+			'body'     => '',
+		);
+	}
+
+	private function get_section_by_id( array $sections, string $id ): ?Section {
+		foreach ( $sections as $section ) {
+			if ( $id === $section->id ) {
+				return $section;
+			}
+		}
+
+		return null;
+	}
+
+	private function get_check_by_key( array $checks, string $key ): ?array {
+		foreach ( $checks as $check ) {
+			if ( $key === $check['key'] ) {
+				return $check;
+			}
+		}
+
+		return null;
+	}
+
+	public function test_run_returns_not_found_when_trunk_does_not_exist() {
+		// No mocked responses at all — every request defaults to a 404.
+		$checker = new Checker( 'nonexistent-plugin' );
+		$report  = $checker->run();
+
+		$this->assertSame( 'nonexistent-plugin', $report['slug'] );
+		$this->assertSame( 'not_found', $report['meta']['error'] );
+		$this->assertSame( array(), $report['sections'] );
+	}
+
+	public function test_run_happy_path_with_matching_stable_tag() {
+		$this->svn_mock_responses = array(
+			'trunk/readme.txt'       => array(
+				'code' => 200,
+				'body' => "=== Example Plugin ===\nStable tag: 1.0.0\nRequires PHP: 7.4\nTested up to: 6.4\n",
+			),
+			'trunk/'                 => array(
+				'code' => 200,
+				'body' => '<a href="example.php">example.php</a>',
+			),
+			'trunk/example.php'      => array(
+				'code' => 200,
+				'body' => "Plugin Name: Example Plugin\nVersion: 1.0.0\n",
+			),
+			'tags/'                  => array( 'code' => 200 ),
+			'assets/'                => array(
+				'code' => 200,
+				'body' => '<a href="banner-772x250.png">banner-772x250.png</a><a href="icon-128x128.png">icon-128x128.png</a>',
+			),
+			'tags/1.0.0/'            => array( 'code' => 200 ),
+			'tags/1.0.0/readme.txt'  => array(
+				'code' => 200,
+				'body' => "=== Example Plugin ===\nStable tag: 1.0.0\n",
+			),
+			'tags/1.0.0/example.php' => array(
+				'code' => 200,
+				'body' => "Plugin Name: Example Plugin\nVersion: 1.0.0\n",
+			),
+		);
+
+		$checker = new Checker( 'example' );
+		$report  = $checker->run();
+
+		$this->assertSame( 'example', $report['slug'] );
+		$this->assertSame(
+			array(
+				'plugin_name'   => 'Example Plugin',
+				'plugin_file'   => 'example.php',
+				'stable_tag'    => '1.0.0',
+				'trunk_version' => '1.0.0',
+				'requires_php'  => '7.4',
+				'tested_up_to'  => '6.4',
+				'svn_url'       => 'https://plugins.svn.wordpress.org/example/',
+			),
+			$report['meta']
+		);
+
+		$root_section = $this->get_section_by_id( $report['sections'], 'root' );
+		$this->assertSame( 'pass', $this->get_check_by_key( $root_section->get_checks(), 'root_tags_exists' )['status'] );
+		$this->assertSame( 'pass', $this->get_check_by_key( $root_section->get_checks(), 'root_assets_exists' )['status'] );
+
+		$trunk_section = $this->get_section_by_id( $report['sections'], 'trunk' );
+		$this->assertSame( 'pass', $this->get_check_by_key( $trunk_section->get_checks(), 'trunk_stable_tag_matches_version' )['status'] );
+
+		$stable_tag_section = $this->get_section_by_id( $report['sections'], 'stable_tag' );
+		$this->assertNotNull( $stable_tag_section );
+		$this->assertSame( 'pass', $this->get_check_by_key( $stable_tag_section->get_checks(), 'tag_readme_stable_tag_matches_trunk' )['status'] );
+		$this->assertSame( 'pass', $this->get_check_by_key( $stable_tag_section->get_checks(), 'tag_php_version_matches_trunk' )['status'] );
+
+		$assets_section = $this->get_section_by_id( $report['sections'], 'assets' );
+		$this->assertSame( 'pass', $this->get_check_by_key( $assets_section->get_checks(), 'assets_banner_present' )['status'] );
+		$this->assertSame( 'pass', $this->get_check_by_key( $assets_section->get_checks(), 'assets_icon_present' )['status'] );
+	}
+
+	public function test_run_without_stable_tag_skips_stable_tag_section() {
+		$this->svn_mock_responses = array(
+			'trunk/readme.txt' => array(
+				'code' => 200,
+				'body' => "=== Example Plugin ===\nRequires PHP: 7.4\n",
+			),
+			'trunk/'           => array(
+				'code' => 200,
+				'body' => '',
+			),
+		);
+
+		$checker = new Checker( 'example' );
+		$report  = $checker->run();
+
+		$this->assertNull( $this->get_section_by_id( $report['sections'], 'stable_tag' ) );
+
+		$trunk_section = $this->get_section_by_id( $report['sections'], 'trunk' );
+		$this->assertSame( 'fail', $this->get_check_by_key( $trunk_section->get_checks(), 'trunk_stable_tag_declared' )['status'] );
+		$this->assertSame( 'warn', $this->get_check_by_key( $trunk_section->get_checks(), 'trunk_main_php_file_found' )['status'] );
+		$this->assertSame( 'warn', $this->get_check_by_key( $trunk_section->get_checks(), 'trunk_version_declared' )['status'] );
+	}
+}

--- a/tests/phpunit/tests/SVN/Checker_Tests.php
+++ b/tests/phpunit/tests/SVN/Checker_Tests.php
@@ -84,6 +84,10 @@ class Checker_Tests extends WP_UnitTestCase {
 
 	public function test_run_happy_path_with_matching_stable_tag() {
 		$this->svn_mock_responses = array(
+			'example/'               => array(
+				'code' => 200,
+				'body' => '<a href="trunk/">trunk</a><a href="tags/">tags</a><a href="assets/">assets</a>',
+			),
 			'trunk/readme.txt'       => array(
 				'code' => 200,
 				'body' => "=== Example Plugin ===\nStable tag: 1.0.0\nRequires PHP: 7.4\nTested up to: 6.4\n",
@@ -96,12 +100,18 @@ class Checker_Tests extends WP_UnitTestCase {
 				'code' => 200,
 				'body' => "Plugin Name: Example Plugin\nVersion: 1.0.0\n",
 			),
-			'tags/'                  => array( 'code' => 200 ),
+			'tags/'                  => array(
+				'code' => 200,
+				'body' => '<a href="1.0.0/">1.0.0</a>',
+			),
 			'assets/'                => array(
 				'code' => 200,
 				'body' => '<a href="banner-772x250.png">banner-772x250.png</a><a href="icon-128x128.png">icon-128x128.png</a>',
 			),
-			'tags/1.0.0/'            => array( 'code' => 200 ),
+			'tags/1.0.0/'            => array(
+				'code' => 200,
+				'body' => '<a href="readme.txt">readme.txt</a><a href="example.php">example.php</a>',
+			),
 			'tags/1.0.0/readme.txt'  => array(
 				'code' => 200,
 				'body' => "=== Example Plugin ===\nStable tag: 1.0.0\n",
@@ -132,18 +142,24 @@ class Checker_Tests extends WP_UnitTestCase {
 		$root_section = $this->get_section_by_id( $report['sections'], 'root' );
 		$this->assertSame( 'pass', $this->get_check_by_key( $root_section->get_checks(), 'root_tags_exists' )['status'] );
 		$this->assertSame( 'pass', $this->get_check_by_key( $root_section->get_checks(), 'root_assets_exists' )['status'] );
+		$this->assertSame( 'pass', $this->get_check_by_key( $root_section->get_checks(), 'root_unexpected_files' )['status'] );
+		$this->assertSame( 'pass', $this->get_check_by_key( $root_section->get_checks(), 'root_tags_unexpected_files' )['status'] );
 
 		$trunk_section = $this->get_section_by_id( $report['sections'], 'trunk' );
 		$this->assertSame( 'pass', $this->get_check_by_key( $trunk_section->get_checks(), 'trunk_stable_tag_matches_version' )['status'] );
+		$this->assertSame( 'pass', $this->get_check_by_key( $trunk_section->get_checks(), 'trunk_unexpected_files' )['status'] );
 
 		$stable_tag_section = $this->get_section_by_id( $report['sections'], 'stable_tag' );
 		$this->assertNotNull( $stable_tag_section );
 		$this->assertSame( 'pass', $this->get_check_by_key( $stable_tag_section->get_checks(), 'tag_readme_stable_tag_matches_trunk' )['status'] );
 		$this->assertSame( 'pass', $this->get_check_by_key( $stable_tag_section->get_checks(), 'tag_php_version_matches_trunk' )['status'] );
+		$this->assertSame( 'pass', $this->get_check_by_key( $stable_tag_section->get_checks(), 'tag_unexpected_files' )['status'] );
 
 		$assets_section = $this->get_section_by_id( $report['sections'], 'assets' );
 		$this->assertSame( 'pass', $this->get_check_by_key( $assets_section->get_checks(), 'assets_banner_present' )['status'] );
 		$this->assertSame( 'pass', $this->get_check_by_key( $assets_section->get_checks(), 'assets_icon_present' )['status'] );
+		$this->assertSame( 'pass', $this->get_check_by_key( $assets_section->get_checks(), 'assets_unexpected_files' )['status'] );
+		$this->assertNull( $this->get_check_by_key( $assets_section->get_checks(), 'assets_blueprint_present' ) );
 	}
 
 	public function test_run_without_stable_tag_skips_stable_tag_section() {
@@ -167,5 +183,203 @@ class Checker_Tests extends WP_UnitTestCase {
 		$this->assertSame( 'fail', $this->get_check_by_key( $trunk_section->get_checks(), 'trunk_stable_tag_declared' )['status'] );
 		$this->assertSame( 'warn', $this->get_check_by_key( $trunk_section->get_checks(), 'trunk_main_php_file_found' )['status'] );
 		$this->assertSame( 'warn', $this->get_check_by_key( $trunk_section->get_checks(), 'trunk_version_declared' )['status'] );
+	}
+
+	public function test_run_flags_unexpected_files_in_svn_root() {
+		$this->svn_mock_responses = array(
+			'example/'         => array(
+				'code' => 200,
+				'body' => '<a href="trunk/">trunk</a><a href="tags/">tags</a><a href="assets/">assets</a><a href="license.txt">license.txt</a>',
+			),
+			'trunk/readme.txt' => array(
+				'code' => 200,
+				'body' => "=== Example Plugin ===\n",
+			),
+			'trunk/'           => array( 'code' => 200 ),
+			'tags/'            => array( 'code' => 200 ),
+			'assets/'          => array( 'code' => 200 ),
+		);
+
+		$checker = new Checker( 'example' );
+		$report  = $checker->run();
+
+		$root_section = $this->get_section_by_id( $report['sections'], 'root' );
+		$check        = $this->get_check_by_key( $root_section->get_checks(), 'root_unexpected_files' );
+
+		$this->assertSame( 'fail', $check['status'] );
+		$this->assertStringContainsString( 'license.txt', $check['detail'] );
+	}
+
+	public function test_run_flags_unexpected_files_in_tags_directory() {
+		$this->svn_mock_responses = array(
+			'trunk/readme.txt' => array(
+				'code' => 200,
+				'body' => "=== Example Plugin ===\nStable tag: 1.0.0\n",
+			),
+			'trunk/'           => array( 'code' => 200 ),
+			'tags/'            => array(
+				'code' => 200,
+				'body' => '<a href="1.0.0/">1.0.0</a><a href="notes.txt">notes.txt</a>',
+			),
+			'assets/'          => array( 'code' => 200 ),
+			'tags/1.0.0/'      => array( 'code' => 200 ),
+		);
+
+		$checker = new Checker( 'example' );
+		$report  = $checker->run();
+
+		$root_section = $this->get_section_by_id( $report['sections'], 'root' );
+		$check        = $this->get_check_by_key( $root_section->get_checks(), 'root_tags_unexpected_files' );
+
+		$this->assertSame( 'fail', $check['status'] );
+		$this->assertStringContainsString( 'notes.txt', $check['detail'] );
+	}
+
+	public function test_run_flags_unexpected_zip_file_in_trunk() {
+		$this->svn_mock_responses = array(
+			'trunk/readme.txt'  => array(
+				'code' => 200,
+				'body' => "=== Example Plugin ===\n",
+			),
+			'trunk/'            => array(
+				'code' => 200,
+				'body' => '<a href="example.php">example.php</a><a href="example.zip">example.zip</a>',
+			),
+			'trunk/example.php' => array(
+				'code' => 200,
+				'body' => "Plugin Name: Example Plugin\nVersion: 1.0.0\n",
+			),
+			'tags/'             => array( 'code' => 200 ),
+			'assets/'           => array( 'code' => 200 ),
+		);
+
+		$checker = new Checker( 'example' );
+		$report  = $checker->run();
+
+		$trunk_section = $this->get_section_by_id( $report['sections'], 'trunk' );
+		$check         = $this->get_check_by_key( $trunk_section->get_checks(), 'trunk_unexpected_files' );
+
+		$this->assertSame( 'fail', $check['status'] );
+		$this->assertStringContainsString( 'example.zip', $check['detail'] );
+	}
+
+	public function test_run_flags_unexpected_zip_file_in_tag_directory() {
+		$this->svn_mock_responses = array(
+			'trunk/readme.txt' => array(
+				'code' => 200,
+				'body' => "=== Example Plugin ===\nStable tag: 1.0.0\n",
+			),
+			'trunk/'           => array( 'code' => 200 ),
+			'tags/'            => array( 'code' => 200 ),
+			'assets/'          => array( 'code' => 200 ),
+			'tags/1.0.0/'      => array(
+				'code' => 200,
+				'body' => '<a href="readme.txt">readme.txt</a><a href="old-build.zip">old-build.zip</a>',
+			),
+		);
+
+		$checker = new Checker( 'example' );
+		$report  = $checker->run();
+
+		$stable_tag_section = $this->get_section_by_id( $report['sections'], 'stable_tag' );
+		$check              = $this->get_check_by_key( $stable_tag_section->get_checks(), 'tag_unexpected_files' );
+
+		$this->assertSame( 'fail', $check['status'] );
+		$this->assertStringContainsString( 'old-build.zip', $check['detail'] );
+	}
+
+	public function test_run_flags_unexpected_files_in_assets_and_ignores_blueprints_folder() {
+		$this->svn_mock_responses = array(
+			'trunk/readme.txt' => array(
+				'code' => 200,
+				'body' => "=== Example Plugin ===\n",
+			),
+			'trunk/'           => array( 'code' => 200 ),
+			'tags/'            => array( 'code' => 200 ),
+			'assets/'          => array(
+				'code' => 200,
+				'body' => '<a href="banner-772x250.png">banner-772x250.png</a><a href="notes.pdf">notes.pdf</a><a href="blueprints/">blueprints</a>',
+			),
+		);
+
+		$checker = new Checker( 'example' );
+		$report  = $checker->run();
+
+		$assets_section = $this->get_section_by_id( $report['sections'], 'assets' );
+		$check          = $this->get_check_by_key( $assets_section->get_checks(), 'assets_unexpected_files' );
+
+		$this->assertSame( 'fail', $check['status'] );
+		$this->assertStringContainsString( 'notes.pdf', $check['detail'] );
+		$this->assertStringNotContainsString( 'blueprints', $check['detail'] );
+	}
+
+	public function test_run_detects_blueprint_file_when_present() {
+		$this->svn_mock_responses = array(
+			'trunk/readme.txt'                 => array(
+				'code' => 200,
+				'body' => "=== Example Plugin ===\n",
+			),
+			'trunk/'                           => array( 'code' => 200 ),
+			'tags/'                            => array( 'code' => 200 ),
+			'assets/'                          => array(
+				'code' => 200,
+				'body' => '<a href="blueprints/">blueprints</a>',
+			),
+			'assets/blueprints/blueprint.json' => array(
+				'code' => 200,
+				'body' => '{}',
+			),
+		);
+
+		$checker = new Checker( 'example' );
+		$report  = $checker->run();
+
+		$assets_section = $this->get_section_by_id( $report['sections'], 'assets' );
+		$check          = $this->get_check_by_key( $assets_section->get_checks(), 'assets_blueprint_present' );
+
+		$this->assertSame( 'pass', $check['status'] );
+	}
+
+	public function test_run_reports_missing_blueprint_file() {
+		$this->svn_mock_responses = array(
+			'trunk/readme.txt' => array(
+				'code' => 200,
+				'body' => "=== Example Plugin ===\n",
+			),
+			'trunk/'           => array( 'code' => 200 ),
+			'tags/'            => array( 'code' => 200 ),
+			'assets/'          => array(
+				'code' => 200,
+				'body' => '<a href="blueprints/">blueprints</a>',
+			),
+		);
+
+		$checker = new Checker( 'example' );
+		$report  = $checker->run();
+
+		$assets_section = $this->get_section_by_id( $report['sections'], 'assets' );
+		$check          = $this->get_check_by_key( $assets_section->get_checks(), 'assets_blueprint_present' );
+
+		$this->assertSame( 'info', $check['status'] );
+	}
+
+	public function test_run_skips_blueprint_check_when_no_blueprints_folder() {
+		$this->svn_mock_responses = array(
+			'trunk/readme.txt' => array(
+				'code' => 200,
+				'body' => "=== Example Plugin ===\n",
+			),
+			'trunk/'           => array( 'code' => 200 ),
+			'tags/'            => array( 'code' => 200 ),
+			'assets/'          => array( 'code' => 200 ),
+		);
+
+		$checker = new Checker( 'example' );
+		$report  = $checker->run();
+
+		$assets_section = $this->get_section_by_id( $report['sections'], 'assets' );
+		$check          = $this->get_check_by_key( $assets_section->get_checks(), 'assets_blueprint_present' );
+
+		$this->assertNull( $check );
 	}
 }

--- a/tests/phpunit/tests/SVN/Checker_Tests.php
+++ b/tests/phpunit/tests/SVN/Checker_Tests.php
@@ -86,7 +86,7 @@ class Checker_Tests extends WP_UnitTestCase {
 		$this->svn_mock_responses = array(
 			'example/'               => array(
 				'code' => 200,
-				'body' => '<a href="trunk/">trunk</a><a href="tags/">tags</a><a href="assets/">assets</a>',
+				'body' => '<a href="trunk/">trunk/</a><a href="tags/">tags/</a><a href="assets/">assets/</a>',
 			),
 			'trunk/readme.txt'       => array(
 				'code' => 200,
@@ -189,7 +189,7 @@ class Checker_Tests extends WP_UnitTestCase {
 		$this->svn_mock_responses = array(
 			'example/'         => array(
 				'code' => 200,
-				'body' => '<a href="trunk/">trunk</a><a href="tags/">tags</a><a href="assets/">assets</a><a href="license.txt">license.txt</a>',
+				'body' => '<a href="trunk/">trunk/</a><a href="tags/">tags/</a><a href="assets/">assets/</a><a href="license.txt">license.txt</a>',
 			),
 			'trunk/readme.txt' => array(
 				'code' => 200,
@@ -298,7 +298,7 @@ class Checker_Tests extends WP_UnitTestCase {
 			'tags/'            => array( 'code' => 200 ),
 			'assets/'          => array(
 				'code' => 200,
-				'body' => '<a href="banner-772x250.png">banner-772x250.png</a><a href="notes.pdf">notes.pdf</a><a href="blueprints/">blueprints</a>',
+				'body' => '<a href="banner-772x250.png">banner-772x250.png</a><a href="notes.pdf">notes.pdf</a><a href="blueprints/">blueprints/</a>',
 			),
 		);
 
@@ -323,7 +323,7 @@ class Checker_Tests extends WP_UnitTestCase {
 			'tags/'                            => array( 'code' => 200 ),
 			'assets/'                          => array(
 				'code' => 200,
-				'body' => '<a href="blueprints/">blueprints</a>',
+				'body' => '<a href="blueprints/">blueprints/</a>',
 			),
 			'assets/blueprints/blueprint.json' => array(
 				'code' => 200,
@@ -350,7 +350,7 @@ class Checker_Tests extends WP_UnitTestCase {
 			'tags/'            => array( 'code' => 200 ),
 			'assets/'          => array(
 				'code' => 200,
-				'body' => '<a href="blueprints/">blueprints</a>',
+				'body' => '<a href="blueprints/">blueprints/</a>',
 			),
 		);
 

--- a/tests/phpunit/tests/SVN/Checker_Tests.php
+++ b/tests/phpunit/tests/SVN/Checker_Tests.php
@@ -84,10 +84,6 @@ class Checker_Tests extends WP_UnitTestCase {
 
 	public function test_run_happy_path_with_matching_stable_tag() {
 		$this->svn_mock_responses = array(
-			'example/'               => array(
-				'code' => 200,
-				'body' => '<a href="trunk/">trunk/</a><a href="tags/">tags/</a><a href="assets/">assets/</a>',
-			),
 			'trunk/readme.txt'       => array(
 				'code' => 200,
 				'body' => "=== Example Plugin ===\nStable tag: 1.0.0\nRequires PHP: 7.4\nTested up to: 6.4\n",
@@ -142,8 +138,6 @@ class Checker_Tests extends WP_UnitTestCase {
 		$root_section = $this->get_section_by_id( $report['sections'], 'root' );
 		$this->assertSame( 'pass', $this->get_check_by_key( $root_section->get_checks(), 'root_tags_exists' )['status'] );
 		$this->assertSame( 'pass', $this->get_check_by_key( $root_section->get_checks(), 'root_assets_exists' )['status'] );
-		$this->assertSame( 'pass', $this->get_check_by_key( $root_section->get_checks(), 'root_unexpected_files' )['status'] );
-		$this->assertSame( 'pass', $this->get_check_by_key( $root_section->get_checks(), 'root_tags_unexpected_files' )['status'] );
 
 		$trunk_section = $this->get_section_by_id( $report['sections'], 'trunk' );
 		$this->assertSame( 'pass', $this->get_check_by_key( $trunk_section->get_checks(), 'trunk_stable_tag_matches_version' )['status'] );
@@ -185,56 +179,6 @@ class Checker_Tests extends WP_UnitTestCase {
 		$this->assertSame( 'warn', $this->get_check_by_key( $trunk_section->get_checks(), 'trunk_version_declared' )['status'] );
 	}
 
-	public function test_run_flags_unexpected_files_in_svn_root() {
-		$this->svn_mock_responses = array(
-			'example/'         => array(
-				'code' => 200,
-				'body' => '<a href="trunk/">trunk/</a><a href="tags/">tags/</a><a href="assets/">assets/</a><a href="license.txt">license.txt</a>',
-			),
-			'trunk/readme.txt' => array(
-				'code' => 200,
-				'body' => "=== Example Plugin ===\n",
-			),
-			'trunk/'           => array( 'code' => 200 ),
-			'tags/'            => array( 'code' => 200 ),
-			'assets/'          => array( 'code' => 200 ),
-		);
-
-		$checker = new Checker( 'example' );
-		$report  = $checker->run();
-
-		$root_section = $this->get_section_by_id( $report['sections'], 'root' );
-		$check        = $this->get_check_by_key( $root_section->get_checks(), 'root_unexpected_files' );
-
-		$this->assertSame( 'fail', $check['status'] );
-		$this->assertStringContainsString( 'license.txt', $check['detail'] );
-	}
-
-	public function test_run_flags_unexpected_files_in_tags_directory() {
-		$this->svn_mock_responses = array(
-			'trunk/readme.txt' => array(
-				'code' => 200,
-				'body' => "=== Example Plugin ===\nStable tag: 1.0.0\n",
-			),
-			'trunk/'           => array( 'code' => 200 ),
-			'tags/'            => array(
-				'code' => 200,
-				'body' => '<a href="1.0.0/">1.0.0</a><a href="notes.txt">notes.txt</a>',
-			),
-			'assets/'          => array( 'code' => 200 ),
-			'tags/1.0.0/'      => array( 'code' => 200 ),
-		);
-
-		$checker = new Checker( 'example' );
-		$report  = $checker->run();
-
-		$root_section = $this->get_section_by_id( $report['sections'], 'root' );
-		$check        = $this->get_check_by_key( $root_section->get_checks(), 'root_tags_unexpected_files' );
-
-		$this->assertSame( 'fail', $check['status'] );
-		$this->assertStringContainsString( 'notes.txt', $check['detail'] );
-	}
-
 	public function test_run_flags_unexpected_zip_file_in_trunk() {
 		$this->svn_mock_responses = array(
 			'trunk/readme.txt'  => array(
@@ -259,7 +203,7 @@ class Checker_Tests extends WP_UnitTestCase {
 		$trunk_section = $this->get_section_by_id( $report['sections'], 'trunk' );
 		$check         = $this->get_check_by_key( $trunk_section->get_checks(), 'trunk_unexpected_files' );
 
-		$this->assertSame( 'fail', $check['status'] );
+		$this->assertSame( 'warn', $check['status'] );
 		$this->assertStringContainsString( 'example.zip', $check['detail'] );
 	}
 
@@ -284,7 +228,7 @@ class Checker_Tests extends WP_UnitTestCase {
 		$stable_tag_section = $this->get_section_by_id( $report['sections'], 'stable_tag' );
 		$check              = $this->get_check_by_key( $stable_tag_section->get_checks(), 'tag_unexpected_files' );
 
-		$this->assertSame( 'fail', $check['status'] );
+		$this->assertSame( 'warn', $check['status'] );
 		$this->assertStringContainsString( 'old-build.zip', $check['detail'] );
 	}
 
@@ -308,7 +252,7 @@ class Checker_Tests extends WP_UnitTestCase {
 		$assets_section = $this->get_section_by_id( $report['sections'], 'assets' );
 		$check          = $this->get_check_by_key( $assets_section->get_checks(), 'assets_unexpected_files' );
 
-		$this->assertSame( 'fail', $check['status'] );
+		$this->assertSame( 'warn', $check['status'] );
 		$this->assertStringContainsString( 'notes.pdf', $check['detail'] );
 		$this->assertStringNotContainsString( 'blueprints', $check['detail'] );
 	}

--- a/tests/phpunit/tests/SVN/Checker_Tests.php
+++ b/tests/phpunit/tests/SVN/Checker_Tests.php
@@ -326,4 +326,32 @@ class Checker_Tests extends WP_UnitTestCase {
 
 		$this->assertNull( $check );
 	}
+
+	public function test_run_skips_stable_tag_section_and_version_match_when_stable_tag_is_trunk() {
+		$this->svn_mock_responses = array(
+			'trunk/readme.txt'  => array(
+				'code' => 200,
+				'body' => "=== Example Plugin ===\nStable tag: trunk\n",
+			),
+			'trunk/'            => array(
+				'code' => 200,
+				'body' => '<a href="example.php">example.php</a>',
+			),
+			'trunk/example.php' => array(
+				'code' => 200,
+				'body' => "Plugin Name: Example Plugin\nVersion: 2.5.0\n",
+			),
+			'tags/'             => array( 'code' => 200 ),
+			'assets/'           => array( 'code' => 200 ),
+		);
+
+		$checker = new Checker( 'example' );
+		$report  = $checker->run();
+
+		$this->assertNull( $this->get_section_by_id( $report['sections'], 'stable_tag' ) );
+
+		$trunk_section = $this->get_section_by_id( $report['sections'], 'trunk' );
+		$this->assertSame( 'pass', $this->get_check_by_key( $trunk_section->get_checks(), 'trunk_stable_tag_declared' )['status'] );
+		$this->assertSame( 'pass', $this->get_check_by_key( $trunk_section->get_checks(), 'trunk_stable_tag_matches_version' )['status'] );
+	}
 }

--- a/tests/phpunit/tests/SVN/Fetcher_Tests.php
+++ b/tests/phpunit/tests/SVN/Fetcher_Tests.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Tests for the Fetcher class.
+ *
+ * @package plugin-check
+ */
+
+namespace SVN;
+
+use WordPress\Plugin_Check\SVN\Fetcher;
+use WP_UnitTestCase;
+
+class Fetcher_Tests extends WP_UnitTestCase {
+
+	protected $fetcher;
+
+	public function set_up() {
+		parent::set_up();
+		$this->fetcher = new Fetcher( 'https://plugins.svn.wordpress.org/example/' );
+	}
+
+	public function test_parse_readme_extracts_fields() {
+		$content = <<<README
+=== My Awesome Plugin ===
+Contributors: someone
+Tags: foo, bar
+Requires at least: 5.0
+Tested up to: 6.4
+Requires PHP: 7.4
+Stable tag: 1.2.3
+
+Description here.
+README;
+
+		$this->assertSame(
+			array(
+				'stable_tag'        => '1.2.3',
+				'requires_at_least' => '5.0',
+				'tested_up_to'      => '6.4',
+				'requires_php'      => '7.4',
+				'name'              => 'My Awesome Plugin',
+			),
+			$this->fetcher->parse_readme( $content )
+		);
+	}
+
+	public function test_parse_readme_supports_markdown_name_header() {
+		$content = <<<README
+# My Awesome Plugin
+
+Stable tag: 2.0.0
+README;
+
+		$data = $this->fetcher->parse_readme( $content );
+
+		$this->assertSame( 'My Awesome Plugin', $data['name'] );
+		$this->assertSame( '2.0.0', $data['stable_tag'] );
+	}
+
+	public function test_parse_readme_returns_empty_array_for_no_matches() {
+		$this->assertSame( array(), $this->fetcher->parse_readme( 'Just some plain text.' ) );
+	}
+
+	public function test_parse_plugin_headers_extracts_fields() {
+		$content = <<<PHP
+<?php
+/**
+ * Plugin Name: My Awesome Plugin
+ * Version: 1.2.3
+ * Requires at least: 5.0
+ * Tested up to: 6.4
+ * Requires PHP: 7.4
+ * Author: John Doe
+ */
+PHP;
+
+		$this->assertSame(
+			array(
+				'Plugin Name'       => 'My Awesome Plugin',
+				'Version'           => '1.2.3',
+				'Requires at least' => '5.0',
+				'Tested up to'      => '6.4',
+				'Requires PHP'      => '7.4',
+				'Author'            => 'John Doe',
+			),
+			$this->fetcher->parse_plugin_headers( $content )
+		);
+	}
+
+	public function test_parse_plugin_headers_returns_empty_array_for_no_matches() {
+		$content = <<<PHP
+<?php
+echo 'Hello world';
+PHP;
+
+		$this->assertSame( array(), $this->fetcher->parse_plugin_headers( $content ) );
+	}
+}

--- a/tests/phpunit/tests/SVN/Fetcher_Tests.php
+++ b/tests/phpunit/tests/SVN/Fetcher_Tests.php
@@ -95,4 +95,25 @@ PHP;
 
 		$this->assertSame( array(), $this->fetcher->parse_plugin_headers( $content ) );
 	}
+
+	public function test_fetch_directory_strips_trailing_slash_from_directory_names() {
+		add_filter(
+			'pre_http_request',
+			function () {
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '<a href="trunk/">trunk/</a><a href="tags/">tags/</a><a href="readme.txt">readme.txt</a>',
+				);
+			}
+		);
+
+		$result = $this->fetcher->fetch_directory( '' );
+
+		$this->assertSame(
+			array( 'trunk', 'tags', 'readme.txt' ),
+			array_column( $result['items'], 'name' )
+		);
+		$this->assertTrue( $result['items'][0]['is_dir'] );
+		$this->assertFalse( $result['items'][2]['is_dir'] );
+	}
 }

--- a/tests/phpunit/tests/SVN/Section_Tests.php
+++ b/tests/phpunit/tests/SVN/Section_Tests.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Tests for the Section class.
+ *
+ * @package plugin-check
+ */
+
+namespace SVN;
+
+use WordPress\Plugin_Check\SVN\Section;
+use WP_UnitTestCase;
+
+class Section_Tests extends WP_UnitTestCase {
+
+	public function test_constructor_sets_id_and_label() {
+		$section = new Section( 'trunk', 'Trunk' );
+
+		$this->assertSame( 'trunk', $section->id );
+		$this->assertSame( 'Trunk', $section->label );
+	}
+
+	public function test_add_check_stores_check() {
+		$section = new Section( 'trunk', 'Trunk' );
+		$section->add_check( 'trunk_readme_found', 'readme.txt found', 'pass', 'trunk/readme.txt' );
+
+		$this->assertSame(
+			array(
+				array(
+					'key'    => 'trunk_readme_found',
+					'label'  => 'readme.txt found',
+					'status' => 'pass',
+					'detail' => 'trunk/readme.txt',
+				),
+			),
+			$section->get_checks()
+		);
+	}
+
+	public function test_add_check_defaults_detail_to_empty_string() {
+		$section = new Section( 'trunk', 'Trunk' );
+		$section->add_check( 'trunk_readme_found', 'readme.txt found', 'pass' );
+
+		$this->assertSame( '', $section->get_checks()[0]['detail'] );
+	}
+
+	public function test_add_check_accumulates_in_order() {
+		$section = new Section( 'trunk', 'Trunk' );
+		$section->add_check( 'check_one', 'Check One', 'pass' );
+		$section->add_check( 'check_two', 'Check Two', 'fail' );
+
+		$checks = $section->get_checks();
+
+		$this->assertCount( 2, $checks );
+		$this->assertSame( 'check_one', $checks[0]['key'] );
+		$this->assertSame( 'check_two', $checks[1]['key'] );
+	}
+
+	public function test_json_serialize() {
+		$section = new Section( 'trunk', 'Trunk' );
+		$section->add_check( 'trunk_readme_found', 'readme.txt found', 'pass', 'trunk/readme.txt' );
+
+		$this->assertSame(
+			array(
+				'id'     => 'trunk',
+				'label'  => 'Trunk',
+				'checks' => $section->get_checks(),
+			),
+			$section->jsonSerialize()
+		);
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/WordPress/plugin-check/issues/1434

## Summary

- Create SVN Checker admin menu page
- Implement AJAX handler for plugin slug checks
- Add JavaScript for asynchronous report rendering
- Add CSS for checker UI and status badges
- Add PHP unit tests for the changes

## Screenshot

<img width="982" height="813" alt="Screenshot 2026-08-10 at 11 43 57 AM" src="https://github.com/user-attachments/assets/0e710e4f-33fc-444f-9b93-384e832e56e1" />


<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Ftools.php%3Fpage%3Dplugin-check%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fplugin-check%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1437-06b7d494e701b7f88f29d1b4ff1078ecd90d5e47.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->