### PR TITLE
Add plugin-check-info.json manifest for third-party paths

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@
 * [Available Checks](checks.md)
 * [AI-Powered Features & Configuration](ai-features.md)
 * [WordPress Functions Compatibility Data](wp-functions-compatibility-data.md)
+* [Plugin Check manifest](plugin-check-info.md)
 * [CLI Commands](CLI.md)
 * [Running Unit tests](running-unit-tests.md)
 * [Releasing a New Version of Plugin](releasing.md)

--- a/docs/plugin-check-info.md
+++ b/docs/plugin-check-info.md
@@ -1,3 +1,5 @@
+[Back to overview](./README.md)
+
 # Plugin Check manifest
 
 Plugin authors can add `plugin-check-info.json` to plugin root to identify bundled third-party code.
@@ -14,3 +16,19 @@ Plugin authors can add `plugin-check-info.json` to plugin root to identify bundl
 Plugin Check keeps errors from declared paths, but hides warning-level findings for those paths. This reduces recommendations intended for plugin authors, such as replacing a library's native PHP function with a WordPress wrapper, without hiding possible errors. Findings outside declared paths remain unchanged.
 
 Manifest is committed with plugin code, so reviewers can inspect declarations. Missing, malformed, or invalid manifest entries are ignored. Paths are relative to plugin root and use `/` separators. Entries match their declared path and files below it, not similarly named paths.
+
+## Visibility
+
+Suppressed warnings are reported, not silently dropped. In CLI table output, Plugin Check shows a notice with the number of suppressed warnings. The AJAX check response includes the `suppressed_warnings` count.
+
+## Opting out
+
+You can disable manifest-based suppression to show all warnings, including from declared third-party paths:
+
+- **CLI**: `wp plugin check <plugin> --ignore-third-party-warnings`.
+- **REST/AJAX**: pass `ignore-third-party-warnings=1` in the check request body.
+- **Programmatic**: return `true` from the `wp_plugin_check_ignore_third_party_warnings` filter after the runner is created:
+
+```php
+add_filter( 'wp_plugin_check_ignore_third_party_warnings', '__return_true' );
+```

--- a/docs/plugin-check-info.md
+++ b/docs/plugin-check-info.md
@@ -1,0 +1,16 @@
+# Plugin Check manifest
+
+Plugin authors can add `plugin-check-info.json` to plugin root to identify bundled third-party code.
+
+```json
+{
+    "third_parties": [
+        "vendor/phpseclib",
+        "libraries/legacy"
+    ]
+}
+```
+
+Plugin Check keeps errors from declared paths, but hides warning-level findings for those paths. This reduces recommendations intended for plugin authors, such as replacing a library's native PHP function with a WordPress wrapper, without hiding possible errors. Findings outside declared paths remain unchanged.
+
+Manifest is committed with plugin code, so reviewers can inspect declarations. Missing, malformed, or invalid manifest entries are ignored. Paths are relative to plugin root and use `/` separators. Entries match their declared path and files below it, not similarly named paths.

--- a/includes/Admin/Admin_AJAX.php
+++ b/includes/Admin/Admin_AJAX.php
@@ -295,6 +295,7 @@ final class Admin_AJAX {
 
 		$include_experimental = 1 === filter_input( INPUT_POST, 'include-experimental', FILTER_VALIDATE_INT );
 		$use_ai               = 1 === filter_input( INPUT_POST, 'use-ai', FILTER_VALIDATE_INT );
+		$ignore_third_party   = 1 === filter_input( INPUT_POST, 'ignore-third-party-warnings', FILTER_VALIDATE_INT );
 		$types                = filter_input( INPUT_POST, 'types', FILTER_DEFAULT, FILTER_FORCE_ARRAY );
 		$types                = is_null( $types ) ? array( 'error', 'warning' ) : $types;
 
@@ -303,6 +304,7 @@ final class Admin_AJAX {
 			$runner->set_check_slugs( $checks );
 			$runner->set_plugin( $plugin );
 			$runner->set_use_ai( $use_ai );
+			$runner->set_ignore_third_party_warnings( $ignore_third_party );
 			$results = $runner->run();
 		} catch ( Exception $error ) {
 			wp_send_json_error(
@@ -339,9 +341,10 @@ final class Admin_AJAX {
 	 */
 	private function prepare_results_response( $results, array $types ) {
 		$response = array(
-			'message'  => __( 'Checks run successfully', 'plugin-check' ),
-			'errors'   => array(),
-			'warnings' => array(),
+			'message'             => __( 'Checks run successfully', 'plugin-check' ),
+			'errors'              => array(),
+			'warnings'            => array(),
+			'suppressed_warnings' => $results->get_third_party_warning_filtered_count(),
 		);
 
 		if ( in_array( 'error', $types, true ) ) {

--- a/includes/CLI/Plugin_Check_Command.php
+++ b/includes/CLI/Plugin_Check_Command.php
@@ -110,6 +110,9 @@ final class Plugin_Check_Command {
 	 * [--ignore-errors]
 	 * : Limit displayed results to exclude errors.
 	 *
+	 * [--ignore-third-party-warnings]
+	 * : Do not suppress warnings from paths declared in plugin-check-info.json.
+	 *
 	 * [--include-experimental]
 	 * : Include experimental checks.
 	 *
@@ -190,6 +193,7 @@ final class Plugin_Check_Command {
 				'format'                        => 'table',
 				'ignore-warnings'               => false,
 				'ignore-errors'                 => false,
+				'ignore-third-party-warnings'   => false,
 				'include-experimental'          => false,
 				'severity'                      => '',
 				'error-severity'                => '',
@@ -262,6 +266,7 @@ final class Plugin_Check_Command {
 			$runner->set_slug( $options['slug'] );
 			$runner->set_mode( $options['mode'] );
 			$runner->set_use_ai( $options['ai'] );
+			$runner->set_ignore_third_party_warnings( (bool) $options['ignore-third-party-warnings'] );
 			if ( ! empty( $options['ai-model'] ) ) {
 				$runner->set_ai_model_preference( $options['ai-model'] );
 			}
@@ -280,6 +285,25 @@ final class Plugin_Check_Command {
 		}
 
 		Plugin_Request_Utility::destroy_runner();
+
+		// Warn about third-party warnings suppressed by the manifest in human-readable table output.
+		if ( $result && 'table' === $options['format'] && empty( $options['ignore-third-party-warnings'] ) ) {
+			$filtered_count = $result->get_third_party_warning_filtered_count();
+			if ( $filtered_count > 0 ) {
+				WP_CLI::warning(
+					sprintf(
+						/* translators: %d: number of suppressed warnings. */
+						_n(
+							'%d warning was suppressed from paths declared in plugin-check-info.json (use --ignore-third-party-warnings to show it).',
+							'%d warnings were suppressed from paths declared in plugin-check-info.json (use --ignore-third-party-warnings to show them).',
+							$filtered_count,
+							'plugin-check'
+						),
+						$filtered_count
+					)
+				);
+			}
+		}
 
 		// Get errors and warnings from the results.
 		$errors = array();

--- a/includes/Checker/Abstract_Check_Runner.php
+++ b/includes/Checker/Abstract_Check_Runner.php
@@ -445,18 +445,7 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 
 		$results = $this->get_checks_instance()->run_checks( $this->get_check_context(), $checks, $this );
 
-		$third_party_paths = Plugin_Config::get_third_party_paths( $this->get_check_context()->path() );
-		if ( ! empty( $third_party_paths ) ) {
-			$results->transform_messages(
-				function ( $message, $is_error, $file ) use ( $third_party_paths ) {
-					if ( ! $is_error && Plugin_Config::is_third_party_file( $file, $third_party_paths ) ) {
-						return false;
-					}
-
-					return $message;
-				}
-			);
-		}
+		$this->filter_third_party_warnings( $results );
 
 		$ai_analysis = array();
 		$ai_stats    = array();
@@ -485,6 +474,33 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 		}
 
 		return $results;
+	}
+
+	/**
+	 * Removes warning-level findings from declared third-party paths.
+	 *
+	 * Errors and findings outside declared paths are kept unchanged.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param Check_Result $results Check results to filter, modified in place.
+	 */
+	private function filter_third_party_warnings( Check_Result $results ) {
+		$third_party_paths = Plugin_Config::get_third_party_paths( $this->get_check_context()->path() );
+
+		if ( empty( $third_party_paths ) ) {
+			return;
+		}
+
+		$results->transform_messages(
+			function ( $message, $is_error, $file ) use ( $third_party_paths ) {
+				if ( ! $is_error && Plugin_Config::is_third_party_file( $file, $third_party_paths ) ) {
+					return false;
+				}
+
+				return $message;
+			}
+		);
 	}
 
 	/**

--- a/includes/Checker/Abstract_Check_Runner.php
+++ b/includes/Checker/Abstract_Check_Runner.php
@@ -44,6 +44,14 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 	protected $use_ai = false;
 
 	/**
+	 * Whether to ignore manifest-based suppression of third-party warnings.
+	 *
+	 * @since 2.1.0
+	 * @var bool
+	 */
+	protected $ignore_third_party_warnings = false;
+
+	/**
 	 * AI model preference for analysis.
 	 *
 	 * @since 2.0.0
@@ -326,6 +334,17 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 	}
 
 	/**
+	 * Sets whether to ignore manifest-based suppression of third-party warnings.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param bool $ignore True to ignore the suppression and show all warnings, false to apply it.
+	 */
+	final public function set_ignore_third_party_warnings( $ignore ) {
+		$this->ignore_third_party_warnings = (bool) $ignore;
+	}
+
+	/**
 	 * Sets the AI model preference for analysis.
 	 *
 	 * @since 2.0.0
@@ -486,21 +505,47 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 	 * @param Check_Result $results Check results to filter, modified in place.
 	 */
 	private function filter_third_party_warnings( Check_Result $results ) {
+		if ( $this->get_ignore_third_party_warnings() ) {
+			return;
+		}
+
 		$third_party_paths = Plugin_Config::get_third_party_paths( $this->get_check_context()->path() );
 
 		if ( empty( $third_party_paths ) ) {
 			return;
 		}
 
+		$filtered = 0;
+
 		$results->transform_messages(
-			function ( $message, $is_error, $file ) use ( $third_party_paths ) {
+			function ( $message, $is_error, $file ) use ( $third_party_paths, &$filtered ) {
 				if ( ! $is_error && Plugin_Config::is_third_party_file( $file, $third_party_paths ) ) {
+					++$filtered;
 					return false;
 				}
 
 				return $message;
 			}
 		);
+
+		if ( $filtered > 0 ) {
+			$results->increment_third_party_warning_filtered_count( $filtered );
+		}
+	}
+
+	/**
+	 * Determines whether manifest-based suppression of third-party warnings should be ignored.
+	 *
+	 * The suppression can be disabled via the runner setting or the
+	 * `wp_plugin_check_ignore_third_party_warnings` filter.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @return bool True to ignore the suppression and show all warnings, false to apply it.
+	 */
+	private function get_ignore_third_party_warnings() {
+		return $this->ignore_third_party_warnings
+			|| (bool) apply_filters( 'wp_plugin_check_ignore_third_party_warnings', false );
 	}
 
 	/**

--- a/includes/Checker/Abstract_Check_Runner.php
+++ b/includes/Checker/Abstract_Check_Runner.php
@@ -12,6 +12,7 @@ use WordPress\Plugin_Check\Admin\Settings_Page;
 use WordPress\Plugin_Check\Checker\Exception\Invalid_Check_Slug_Exception;
 use WordPress\Plugin_Check\Checker\Preparations\Universal_Runtime_Preparation;
 use WordPress\Plugin_Check\Traits\AI_Analyzer;
+use WordPress\Plugin_Check\Utilities\Plugin_Config;
 use WordPress\Plugin_Check\Utilities\Plugin_Request_Utility;
 
 /**
@@ -443,6 +444,19 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 		}
 
 		$results = $this->get_checks_instance()->run_checks( $this->get_check_context(), $checks, $this );
+
+		$third_party_paths = Plugin_Config::get_third_party_paths( $this->get_check_context()->path() );
+		if ( ! empty( $third_party_paths ) ) {
+			$results->transform_messages(
+				function ( $message, $is_error, $file ) use ( $third_party_paths ) {
+					if ( ! $is_error && Plugin_Config::is_third_party_file( $file, $third_party_paths ) ) {
+						return false;
+					}
+
+					return $message;
+				}
+			);
+		}
 
 		$ai_analysis = array();
 		$ai_stats    = array();

--- a/includes/Checker/Check_Result.php
+++ b/includes/Checker/Check_Result.php
@@ -57,6 +57,14 @@ final class Check_Result {
 	protected $warning_count = 0;
 
 	/**
+	 * Number of warnings suppressed from declared third-party paths.
+	 *
+	 * @since 2.1.0
+	 * @var int
+	 */
+	protected $third_party_warning_filtered_count = 0;
+
+	/**
 	 * AI analysis results for false positives.
 	 *
 	 * @since 2.0.0
@@ -258,6 +266,28 @@ final class Check_Result {
 	 */
 	public function get_warning_count() {
 		return $this->warning_count;
+	}
+
+	/**
+	 * Increments the number of warnings suppressed from declared third-party paths.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param int $count Number of suppressed warnings to add. Default 1.
+	 */
+	public function increment_third_party_warning_filtered_count( $count = 1 ) {
+		$this->third_party_warning_filtered_count += (int) $count;
+	}
+
+	/**
+	 * Returns the number of warnings suppressed from declared third-party paths.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @return int Number of suppressed warnings.
+	 */
+	public function get_third_party_warning_filtered_count() {
+		return $this->third_party_warning_filtered_count;
 	}
 
 	/**

--- a/includes/Utilities/Plugin_Config.php
+++ b/includes/Utilities/Plugin_Config.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Class WordPress\Plugin_Check\Utilities\Plugin_Config
+ *
+ * @package plugin-check
+ */
+
+namespace WordPress\Plugin_Check\Utilities;
+
+/**
+ * Reads optional plugin configuration.
+ *
+ * @since 2.1.0
+ */
+final class Plugin_Config {
+
+	/**
+	 * Configuration file name.
+	 *
+	 * @var string
+	 */
+	const FILE_NAME = 'plugin-check-info.json';
+
+	/**
+	 * Returns paths declared as third-party code.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param string $plugin_path Absolute plugin path.
+	 * @return string[] Relative third-party paths.
+	 */
+	public static function get_third_party_paths( $plugin_path ) {
+		$config_file = trailingslashit( $plugin_path ) . self::FILE_NAME;
+
+		if ( ! is_readable( $config_file ) ) {
+			return array();
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Read plugin-local JSON configuration.
+		$contents = file_get_contents( $config_file );
+		if ( false === $contents ) {
+			return array();
+		}
+
+		$config = json_decode( $contents, true );
+
+		if ( ! is_array( $config ) || empty( $config['third_parties'] ) || ! is_array( $config['third_parties'] ) ) {
+			return array();
+		}
+
+		$paths = array();
+		foreach ( $config['third_parties'] as $path ) {
+			if ( ! is_string( $path ) ) {
+				continue;
+			}
+
+			$path = self::normalize_path( $path );
+			if ( '' !== $path ) {
+				$paths[] = $path;
+			}
+		}
+
+		return array_values( array_unique( $paths ) );
+	}
+
+	/**
+	 * Checks whether a relative file is inside a declared path.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param string   $file Relative file path.
+	 * @param string[] $paths Relative third-party paths.
+	 * @return bool Whether the file is inside a declared path.
+	 */
+	public static function is_third_party_file( $file, array $paths ) {
+		$file = self::normalize_path( $file );
+
+		if ( '' === $file ) {
+			return false;
+		}
+
+		foreach ( $paths as $path ) {
+			if ( $file === $path || 0 === strpos( $file, $path . '/' ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Normalizes and validates a relative plugin path.
+	 *
+	 * @param string $path Plugin-relative path.
+	 * @return string Normalized path, or empty string when invalid.
+	 */
+	private static function normalize_path( $path ) {
+		$path = trim( str_replace( '\\', '/', $path ), " /\t\n\r\0\x0B" );
+
+		if ( '' === $path || '/' === substr( $path, 0, 1 ) || preg_match( '#^[A-Za-z]:/#', $path ) ) {
+			return '';
+		}
+
+		$segments = explode( '/', $path );
+		foreach ( $segments as $segment ) {
+			if ( '' === $segment || '.' === $segment || '..' === $segment ) {
+				return '';
+			}
+		}
+
+		return implode( '/', $segments );
+	}
+}

--- a/tests/phpunit/testdata/Checks/Warning_Check.php
+++ b/tests/phpunit/testdata/Checks/Warning_Check.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace WordPress\Plugin_Check\Test_Data;
+
+use WordPress\Plugin_Check\Checker\Check_Categories;
+use WordPress\Plugin_Check\Checker\Check_Result;
+use WordPress\Plugin_Check\Checker\Static_Check;
+use WordPress\Plugin_Check\Traits\Stable_Check;
+
+class Warning_Check implements Static_Check {
+
+	use Stable_Check;
+
+	public function run( Check_Result $check_result ) {
+		$check_result->add_message(
+			false,
+			'Warning message',
+			array(
+				'code' => 'check_warning',
+				'file' => 'vendor/phpseclib/file.php',
+			)
+		);
+		$check_result->add_message(
+			false,
+			'Outside warning message',
+			array(
+				'code' => 'check_warning_outside',
+				'file' => 'includes/file.php',
+			)
+		);
+		$check_result->add_message(
+			true,
+			'Error message',
+			array(
+				'code' => 'check_error',
+				'file' => 'vendor/phpseclib/file.php',
+			)
+		);
+	}
+
+	public function get_categories() {
+		return array( Check_Categories::CATEGORY_GENERAL );
+	}
+
+	public function get_description(): string {
+		return '';
+	}
+
+	public function get_documentation_url(): string {
+		return '';
+	}
+}

--- a/tests/phpunit/testdata/plugins/test-plugin-plugin-check-info-invalid/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-plugin-check-info-invalid/load.php
@@ -1,0 +1,4 @@
+<?php
+/*
+ * Plugin Name: Test Plugin Invalid Config
+ */

--- a/tests/phpunit/testdata/plugins/test-plugin-plugin-check-info-invalid/plugin-check-info.json
+++ b/tests/phpunit/testdata/plugins/test-plugin-plugin-check-info-invalid/plugin-check-info.json
@@ -1,0 +1,1 @@
+{"third_parties": ["vendor/phpseclib",]

--- a/tests/phpunit/testdata/plugins/test-plugin-plugin-check-info/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-plugin-check-info/load.php
@@ -1,0 +1,4 @@
+<?php
+/*
+ * Plugin Name: Test Plugin Config
+ */

--- a/tests/phpunit/testdata/plugins/test-plugin-plugin-check-info/plugin-check-info.json
+++ b/tests/phpunit/testdata/plugins/test-plugin-plugin-check-info/plugin-check-info.json
@@ -1,0 +1,6 @@
+{
+    "third_parties": [
+        "vendor\\phpseclib",
+        " /libraries/legacy/ "
+    ]
+}

--- a/tests/phpunit/tests/Checker/CLI_Runner_Tests.php
+++ b/tests/phpunit/tests/Checker/CLI_Runner_Tests.php
@@ -230,6 +230,65 @@ class CLI_Runner_Tests extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'vendor/phpseclib/file.php', $results->get_warnings() );
 		$this->assertArrayHasKey( 'includes/file.php', $results->get_warnings() );
 		$this->assertArrayHasKey( 'vendor/phpseclib/file.php', $results->get_errors() );
+		$this->assertSame( 1, $results->get_third_party_warning_filtered_count() );
+	}
+
+	public function test_run_ignores_third_party_filter_with_setter() {
+		$_SERVER['argv'] = array(
+			'wp',
+			'plugin',
+			'check',
+			UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-check-info',
+			'--checks=warning-check',
+		);
+
+		add_filter(
+			'wp_plugin_check_checks',
+			function () {
+				return array( 'warning-check' => new Warning_Check() );
+			}
+		);
+
+		$runner           = new CLI_Runner();
+		$cleanup          = $runner->prepare();
+		$this->cleanups[] = $cleanup;
+
+		$runner->set_ignore_third_party_warnings( true );
+		$results = $runner->run();
+
+		$this->assertArrayHasKey( 'vendor/phpseclib/file.php', $results->get_warnings() );
+		$this->assertArrayHasKey( 'includes/file.php', $results->get_warnings() );
+		$this->assertArrayHasKey( 'vendor/phpseclib/file.php', $results->get_errors() );
+		$this->assertSame( 0, $results->get_third_party_warning_filtered_count() );
+	}
+
+	public function test_run_ignores_third_party_filter_with_hook() {
+		$_SERVER['argv'] = array(
+			'wp',
+			'plugin',
+			'check',
+			UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-check-info',
+			'--checks=warning-check',
+		);
+
+		add_filter(
+			'wp_plugin_check_checks',
+			function () {
+				return array( 'warning-check' => new Warning_Check() );
+			}
+		);
+
+		add_filter( 'wp_plugin_check_ignore_third_party_warnings', '__return_true' );
+
+		$runner           = new CLI_Runner();
+		$cleanup          = $runner->prepare();
+		$this->cleanups[] = $cleanup;
+		$results          = $runner->run();
+
+		$this->assertArrayHasKey( 'vendor/phpseclib/file.php', $results->get_warnings() );
+		$this->assertArrayHasKey( 'includes/file.php', $results->get_warnings() );
+		$this->assertArrayHasKey( 'vendor/phpseclib/file.php', $results->get_errors() );
+		$this->assertSame( 0, $results->get_third_party_warning_filtered_count() );
 	}
 
 	public function test_runner_initialized_early_throws_plugin_basename_exception() {

--- a/tests/phpunit/tests/Checker/CLI_Runner_Tests.php
+++ b/tests/phpunit/tests/Checker/CLI_Runner_Tests.php
@@ -10,6 +10,7 @@ use WordPress\Plugin_Check\Checker\CLI_Runner;
 use WordPress\Plugin_Check\Test_Data\Empty_Check;
 use WordPress\Plugin_Check\Test_Data\Error_Check;
 use WordPress\Plugin_Check\Test_Data\Runtime_Check;
+use WordPress\Plugin_Check\Test_Data\Warning_Check;
 use WordPress\Plugin_Check\Test_Utils\Traits\With_Mock_Filesystem;
 
 class CLI_Runner_Tests extends WP_UnitTestCase {
@@ -203,6 +204,32 @@ class CLI_Runner_Tests extends WP_UnitTestCase {
 		$this->assertInstanceOf( Check_Result::class, $results );
 		$this->assertEmpty( $results->get_warnings() );
 		$this->assertNotEmpty( $results->get_errors() );
+	}
+
+	public function test_run_filters_third_party_warnings() {
+		$_SERVER['argv'] = array(
+			'wp',
+			'plugin',
+			'check',
+			UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-check-info',
+			'--checks=warning-check',
+		);
+
+		add_filter(
+			'wp_plugin_check_checks',
+			function () {
+				return array( 'warning-check' => new Warning_Check() );
+			}
+		);
+
+		$runner           = new CLI_Runner();
+		$cleanup          = $runner->prepare();
+		$this->cleanups[] = $cleanup;
+		$results          = $runner->run();
+
+		$this->assertArrayNotHasKey( 'vendor/phpseclib/file.php', $results->get_warnings() );
+		$this->assertArrayHasKey( 'includes/file.php', $results->get_warnings() );
+		$this->assertArrayHasKey( 'vendor/phpseclib/file.php', $results->get_errors() );
 	}
 
 	public function test_runner_initialized_early_throws_plugin_basename_exception() {

--- a/tests/phpunit/tests/Checker/Check_Result_Tests.php
+++ b/tests/phpunit/tests/Checker/Check_Result_Tests.php
@@ -188,4 +188,32 @@ class Check_Result_Tests extends WP_UnitTestCase {
 
 		$this->assertEquals( 1, $this->check_result->get_error_count() );
 	}
+
+	public function test_transform_messages_removes_messages_and_updates_counts() {
+		$this->check_result->add_message(
+			false,
+			'Third-party warning',
+			array(
+				'file' => 'test-plugin/vendor/library/file.php',
+			)
+		);
+		$this->check_result->add_message(
+			true,
+			'Third-party error',
+			array(
+				'file' => 'test-plugin/vendor/library/file.php',
+			)
+		);
+
+		$this->check_result->transform_messages(
+			function ( $message, $is_error, $file ) {
+				return $is_error || 0 !== strpos( $file, 'vendor/library/' ) ? $message : false;
+			}
+		);
+
+		$this->assertSame( 0, $this->check_result->get_warning_count() );
+		$this->assertSame( 1, $this->check_result->get_error_count() );
+		$this->assertEmpty( $this->check_result->get_warnings() );
+		$this->assertNotEmpty( $this->check_result->get_errors() );
+	}
 }

--- a/tests/phpunit/tests/Checker/Check_Result_Tests.php
+++ b/tests/phpunit/tests/Checker/Check_Result_Tests.php
@@ -216,4 +216,13 @@ class Check_Result_Tests extends WP_UnitTestCase {
 		$this->assertEmpty( $this->check_result->get_warnings() );
 		$this->assertNotEmpty( $this->check_result->get_errors() );
 	}
+
+	public function test_third_party_warning_filtered_count_increments() {
+		$this->assertSame( 0, $this->check_result->get_third_party_warning_filtered_count() );
+
+		$this->check_result->increment_third_party_warning_filtered_count();
+		$this->check_result->increment_third_party_warning_filtered_count();
+
+		$this->assertSame( 2, $this->check_result->get_third_party_warning_filtered_count() );
+	}
 }

--- a/tests/phpunit/tests/Utilities/Plugin_Config_Tests.php
+++ b/tests/phpunit/tests/Utilities/Plugin_Config_Tests.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Tests for the Plugin_Config class.
+ *
+ * @package plugin-check
+ */
+
+use WordPress\Plugin_Check\Utilities\Plugin_Config;
+
+class Plugin_Config_Tests extends WP_UnitTestCase {
+
+	public function test_get_third_party_paths_returns_configured_paths() {
+		$paths = Plugin_Config::get_third_party_paths( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-check-info' );
+
+		$this->assertSame( array( 'vendor/phpseclib', 'libraries/legacy' ), $paths );
+	}
+
+	public function test_get_third_party_paths_ignores_missing_config() {
+		$this->assertSame( array(), Plugin_Config::get_third_party_paths( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-wp-functions-compatibility-with-errors' ) );
+	}
+
+	public function test_get_third_party_paths_ignores_invalid_config() {
+		$this->assertSame( array(), Plugin_Config::get_third_party_paths( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-check-info-invalid' ) );
+	}
+
+	/**
+	 * @dataProvider third_party_file_provider
+	 */
+	public function test_is_third_party_file( $file, $expected ) {
+		$this->assertSame( $expected, Plugin_Config::is_third_party_file( $file, array( 'vendor/phpseclib' ) ) );
+	}
+
+	public function third_party_file_provider() {
+		return array(
+			'in declared directory'   => array( 'vendor/phpseclib/Crypt/Hash.php', true ),
+			'declared file'           => array( 'vendor/phpseclib', true ),
+			'near matching directory' => array( 'vendor/phpseclib2/Crypt/Hash.php', false ),
+			'outside directory'       => array( 'includes/Plugin.php', false ),
+			'normalizes backslashes'  => array( 'vendor\\phpseclib\\Crypt\\Hash.php', true ),
+			'rejects traversal'       => array( 'vendor/phpseclib/../other.php', false ),
+		);
+	}
+}


### PR DESCRIPTION
## What?
Closes #760

Add support for a committed `plugin-check-info.json` manifest that declares bundled third-party paths.

## Why?
Plugin Check currently reports warning-level recommendations inside vendor code that plugin authors do not control. This creates noisy results. Errors must remain visible.

## How?
Add a shared configuration helper that reads and validates the manifest from the plugin root. After checks run, the shared runner removes warnings whose plugin-relative file path matches a declared third-party path. Errors and findings outside declared paths remain unchanged. The same result filtering is used by CLI and admin AJAX runs.

Path matching uses normalized, relative paths with directory boundaries. Missing or malformed manifests are treated as no configuration.

## Changes
- Add `--ignore-third-party-warnings` to WP-CLI to show warnings from declared third-party paths.
- Add `ignore-third-party-warnings=1` for admin AJAX requests.
- Add the `wp_plugin_check_ignore_third_party_warnings` filter for programmatic opt-out.
- Report the number of suppressed warnings in CLI table output and the AJAX `suppressed_warnings` response field.
- Keep errors and findings outside declared third-party paths unchanged.

## Testing Instructions
1. Add `plugin-check-info.json` to a test plugin root:
   ```json
   {
       &#34;third_parties&#34;: [
           &#34;vendor/example-library&#34;
       ]
   }
   ```
2. Put code that produces a warning and an error under `vendor/example-library/`.
3. Put code that produces a warning outside that directory.
4. Run Plugin Check from Tools &gt; Plugin Check and with WP-CLI.
5. Confirm warnings under the declared path are hidden.
6. Confirm errors under the declared path remain visible.
7. Confirm warnings outside the declared path remain visible.
8. Remove or rename the manifest and confirm normal results return.

Automated validation:
- Focused PHPUnit tests pass in wp-env: 28 tests, 69 assertions.
- `composer lint` passes.
- `composer phpstan` passes.
- `git diff --check` passes.

The local PHPUnit command without wp-env was blocked by missing WordPress test environment constants. CodeRabbit follow-up review was rate limited after the initial review completed with no findings.

## AI Usage Disclosure
- [ ] This PR was created without the help of AI tools
- [x] This PR includes AI-assisted code or content

Used an AI coding assistant to inspect the repository, implement the manifest parsing and result filtering, add tests and documentation, and run validation commands. All changes were reviewed and tested locally.

## Screenshots or screencast 

Not applicable. This changes check result filtering and does not change the UI layout.


<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Ftools.php%3Fpage%3Dplugin-check%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fplugin-check%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1439-a0ea751bb3777ba13f5888682750a613c2a15574.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" rel="nofollow noreferrer noopener" target="_blank">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57"/>
</a>

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Ftools.php%3Fpage%3Dplugin-check%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fplugin-check%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1439-21b313938f0ae782a38fa4c16ad677a086c52d19.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->