### PR TITLE
Add check for functions ending in __premium_only

### DIFF
--- a/includes/Checker/Checks/Plugin_Repo/Premium_Only_Function_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Premium_Only_Function_Check.php
@@ -16,7 +16,7 @@ use WordPress\Plugin_Check\Traits\Stable_Check;
 /**
  * Check to detect functions ending in __premium_only.
  *
- * @since 1.2.0
+ * @since x.x.x
  */
 class Premium_Only_Function_Check extends Abstract_File_Check {
 
@@ -28,7 +28,7 @@ class Premium_Only_Function_Check extends Abstract_File_Check {
 	 *
 	 * Every check must have at least one category.
 	 *
-	 * @since 1.2.0
+	 * @since x.x.x
 	 *
 	 * @return array The categories for the check.
 	 */
@@ -39,7 +39,7 @@ class Premium_Only_Function_Check extends Abstract_File_Check {
 	/**
 	 * Amends the given result by running the check on the given list of files.
 	 *
-	 * @since 1.2.0
+	 * @since x.x.x
 	 *
 	 * @param Check_Result $result The check result to amend.
 	 * @param array        $files  List of absolute file paths.
@@ -68,7 +68,7 @@ class Premium_Only_Function_Check extends Abstract_File_Check {
 	 *
 	 * Every check must have a short description explaining what the check does.
 	 *
-	 * @since 1.2.0
+	 * @since x.x.x
 	 *
 	 * @return string Description.
 	 */
@@ -81,7 +81,7 @@ class Premium_Only_Function_Check extends Abstract_File_Check {
 	 *
 	 * Every check must have a URL with further information about the check.
 	 *
-	 * @since 1.2.0
+	 * @since x.x.x
 	 *
 	 * @return string The documentation URL.
 	 */

--- a/includes/Checker/Checks/Plugin_Repo/Premium_Only_Function_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Premium_Only_Function_Check.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Class Premium_Only_Function_Check.
+ *
+ * @package plugin-check
+ */
+
+namespace WordPress\Plugin_Check\Checker\Checks\Plugin_Repo;
+
+use WordPress\Plugin_Check\Checker\Check_Categories;
+use WordPress\Plugin_Check\Checker\Check_Result;
+use WordPress\Plugin_Check\Checker\Checks\Abstract_File_Check;
+use WordPress\Plugin_Check\Traits\Amend_Check_Result;
+use WordPress\Plugin_Check\Traits\Stable_Check;
+
+/**
+ * Check to detect functions ending in __premium_only.
+ *
+ * @since 1.2.0
+ */
+class Premium_Only_Function_Check extends Abstract_File_Check {
+
+	use Amend_Check_Result;
+	use Stable_Check;
+
+	/**
+	 * Gets the categories for the check.
+	 *
+	 * Every check must have at least one category.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @return array The categories for the check.
+	 */
+	public function get_categories() {
+		return array( Check_Categories::CATEGORY_PLUGIN_REPO );
+	}
+
+	/**
+	 * Amends the given result by running the check on the given list of files.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param Check_Result $result The check result to amend.
+	 * @param array        $files  List of absolute file paths.
+	 */
+	protected function check_files( Check_Result $result, array $files ) {
+		$php_files = self::filter_files_by_extension( $files, 'php' );
+		$matches   = self::files_preg_match_all( '/\bfunction\s+[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*__premium_only\s*\(/i', $php_files );
+
+		if ( ! empty( $matches ) ) {
+			foreach ( $matches as $match ) {
+				$this->add_result_error_for_file(
+					$result,
+					__( 'Function declarations ending in __premium_only look like premium/pro-only code and should not be included in a WordPress.org plugin.', 'plugin-check' ),
+					'premium_only_function_found',
+					$match['file'],
+					$match['line'],
+					$match['column'],
+					'https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/'
+				);
+			}
+		}
+	}
+
+	/**
+	 * Gets the description for the check.
+	 *
+	 * Every check must have a short description explaining what the check does.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @return string Description.
+	 */
+	public function get_description(): string {
+		return __( 'Detects function declarations ending in __premium_only.', 'plugin-check' );
+	}
+
+	/**
+	 * Gets the documentation URL for the check.
+	 *
+	 * Every check must have a URL with further information about the check.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @return string The documentation URL.
+	 */
+	public function get_documentation_url(): string {
+		return __( 'https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/', 'plugin-check' );
+	}
+}

--- a/includes/Checker/Default_Check_Repository.php
+++ b/includes/Checker/Default_Check_Repository.php
@@ -14,6 +14,7 @@ namespace WordPress\Plugin_Check\Checker;
  */
 class Default_Check_Repository extends Empty_Check_Repository {
 
+
 	/**
 	 * True if the class was fully initialized.
 	 *
@@ -105,6 +106,7 @@ class Default_Check_Repository extends Empty_Check_Repository {
 				'external_admin_menu_links'  => new Checks\Plugin_Repo\External_Admin_Menu_Links_Check(),
 				'wp_functions_compatibility' => new Checks\Plugin_Repo\WP_Functions_Compatibility_Check(),
 				'ai_provider'                => new Checks\General\AI_Provider_Check(),
+				'premium_only_function'      => new Checks\Plugin_Repo\Premium_Only_Function_Check(),
 			)
 		);
 

--- a/tests/phpunit/testdata/plugins/test-plugin-premium-only-function-with-errors/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-premium-only-function-with-errors/load.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Plugin Name: Premium Only Function Test
+ * Description: Test plugin containing functions named with the __premium_only suffix.
+ * Author: Monzur Alam
+ * Version: 1.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+function poft_register_settings__premium_only() {
+	register_setting( 'poft_settings', 'poft_enabled' );
+}
+
+function poft_admin_notice__premium_only() {
+	echo '<div class="notice notice-info"><p>Premium-only test notice.</p></div>';
+}

--- a/tests/phpunit/testdata/plugins/test-plugin-premium-only-function-with-errors/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-premium-only-function-with-errors/load.php
@@ -2,7 +2,6 @@
 /**
  * Plugin Name: Premium Only Function Test
  * Description: Test plugin containing functions named with the __premium_only suffix.
- * Author: Monzur Alam
  * Version: 1.0.0
  */
 

--- a/tests/phpunit/testdata/plugins/test-plugin-premium-only-function-without-errors/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-premium-only-function-without-errors/load.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Plugin Name: Premium Only Function Clean Test
+ * Description: Test plugin containing standard functions without __premium_only suffix.
+ * Author: Monzur Alam
+ * Version: 1.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+function poft_register_settings() {
+	register_setting( 'poft_settings', 'poft_enabled' );
+}
+
+function poft_admin_notice() {
+	echo '<div class="notice notice-info"><p>Standard test notice.</p></div>';
+}

--- a/tests/phpunit/testdata/plugins/test-plugin-premium-only-function-without-errors/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-premium-only-function-without-errors/load.php
@@ -2,7 +2,6 @@
 /**
  * Plugin Name: Premium Only Function Clean Test
  * Description: Test plugin containing standard functions without __premium_only suffix.
- * Author: Monzur Alam
  * Version: 1.0.0
  */
 

--- a/tests/phpunit/tests/Checker/Checks/Premium_Only_Function_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Premium_Only_Function_Check_Tests.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Tests for the Premium_Only_Function_Check class.
+ *
+ * @package plugin-check
+ */
+
+use WordPress\Plugin_Check\Checker\Check_Context;
+use WordPress\Plugin_Check\Checker\Check_Result;
+use WordPress\Plugin_Check\Checker\Checks\Plugin_Repo\Premium_Only_Function_Check;
+
+class Premium_Only_Function_Check_Tests extends WP_UnitTestCase {
+
+	public function test_run_with_errors() {
+		$check         = new Premium_Only_Function_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-premium-only-function-with-errors/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$check->run( $check_result );
+
+		$errors = $check_result->get_errors();
+
+		$this->assertNotEmpty( $errors );
+		$this->assertArrayHasKey( 'load.php', $errors );
+		$this->assertEquals( 2, $check_result->get_error_count() );
+
+		$this->assertArrayHasKey( 13, $errors['load.php'] );
+		$this->assertArrayHasKey( 17, $errors['load.php'] );
+		$this->assertEquals( 'premium_only_function_found', $errors['load.php'][13][1][0]['code'] );
+		$this->assertEquals( 'premium_only_function_found', $errors['load.php'][17][1][0]['code'] );
+	}
+
+	public function test_run_without_errors() {
+		$check         = new Premium_Only_Function_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-premium-only-function-without-errors/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$check->run( $check_result );
+
+		$errors = $check_result->get_errors();
+
+		$this->assertEmpty( $errors );
+		$this->assertEquals( 0, $check_result->get_error_count() );
+	}
+}

--- a/tests/phpunit/tests/Checker/Checks/Premium_Only_Function_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Premium_Only_Function_Check_Tests.php
@@ -22,12 +22,12 @@ class Premium_Only_Function_Check_Tests extends WP_UnitTestCase {
 
 		$this->assertNotEmpty( $errors );
 		$this->assertArrayHasKey( 'load.php', $errors );
-		$this->assertEquals( 2, $check_result->get_error_count() );
+		$this->assertSame( 2, $check_result->get_error_count() );
 
-		$this->assertArrayHasKey( 13, $errors['load.php'] );
-		$this->assertArrayHasKey( 17, $errors['load.php'] );
-		$this->assertEquals( 'premium_only_function_found', $errors['load.php'][13][1][0]['code'] );
-		$this->assertEquals( 'premium_only_function_found', $errors['load.php'][17][1][0]['code'] );
+		$this->assertArrayHasKey( 12, $errors['load.php'] );
+		$this->assertArrayHasKey( 16, $errors['load.php'] );
+		$this->assertSame( 'premium_only_function_found', $errors['load.php'][12][1][0]['code'] );
+		$this->assertSame( 'premium_only_function_found', $errors['load.php'][16][1][0]['code'] );
 	}
 
 	public function test_run_without_errors() {
@@ -40,6 +40,6 @@ class Premium_Only_Function_Check_Tests extends WP_UnitTestCase {
 		$errors = $check_result->get_errors();
 
 		$this->assertEmpty( $errors );
-		$this->assertEquals( 0, $check_result->get_error_count() );
+		$this->assertSame( 0, $check_result->get_error_count() );
 	}
 }


### PR DESCRIPTION
## What?
<!-- Link this PR to its associated issue. -->
Closes #1443 

<!-- In a few words, what is the PR actually doing? -->
Adds a static check `Premium_Only_Function_Check` in the `Plugin Repo` category to detect PHP function declarations whose names end with the `__premium_only` suffix.

As a potential future enhancement, this check could be upgraded to a token-aware sniff to ensure occurrences of `__premium_only` inside PHP comments, docblocks, or string literals are completely ignored.

## Why?
<!-- Why is this PR necessary? What problem is it solving? -->
WordPress.org plugin directory guidelines do not allow code intended strictly for a paid/pro/premium version to be included in free plugin submissions. Detecting common naming conventions like `__premium_only` helps authors identify and relocate premium-only code before submitting plugins for review.

## How?
<!-- How is your PR addressing the issue? What are the implementation details? -->

- Created class extending `Abstract_File_Check`.
- Uses regex pattern to scan PHP files and report a `premium_only_function_found` error.
- Registered the function check in `Default_Check_Repository`.
- Added PHPUnit unit test suite and fixture test plugins.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

1. Run PHPCS linting and static analysis:

```
composer lint
composer phpstan
```

2. Start test environment stack:

```
npm run wp-env:start:tests
```

3. Run the new unit test suite:

```
npm run test-php -- --filter=Premium_Only_Function_Check_Tests
```

4. Verify that both tests pass - 2 tests, 9 assertions.

## AI Usage Disclosure
<!-- See the WordPress AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/ -->

- [ ] This PR was created without the help of AI tools
- [x] This PR includes AI-assisted code or content

If AI tools were used, please describe how they were used:
<!-- e.g., "Used GitHub Copilot for code suggestions", "Used ChatGPT to draft documentation" -->

- AI Tool: Gemini CLI
- Usage: Used to generate boilerplate code for `Premium_Only_Function_Check`, draft PHPUnit unit test cases, and verify WordPress coding standards compliance. Evaluated architectural trade-offs and manually verified all code, tests, and static analysis outputs.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Ftools.php%3Fpage%3Dplugin-check%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fplugin-check%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1447-953af9c0f1aef512f57ea30b35b71d6bb91ddf3d.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->