### PR TITLE
docs: explain check result codes and severity

### DIFF
--- a/docs/checks.md
+++ b/docs/checks.md
@@ -38,6 +38,26 @@
 | non_blocking_scripts | performance | Checks whether scripts and styles are enqueued using a recommended loading strategy. | [Learn more](https://developer.wordpress.org/plugins/) |
 | ai_provider | general | Recommends the WordPress AI Client when a plugin integrates directly with a third-party AI provider. | [Learn more](https://developer.wordpress.org/plugins/) |
 
+## Results and severity
+
+The check name in the table is a **check slug**. When a check finds a problem, it emits a separate **result code**. Result codes are the values accepted by `--ignore-codes` and are included in the CLI output alongside the result type and severity.
+
+Each result has a type (`ERROR` or `WARNING`) and a severity from 1 (lowest) to 10 (highest). A check can emit more than one result code, and the same code can be emitted for multiple files. Unless a check overrides it, a result uses the default severity of 5.
+
+For example, the `code_obfuscation` check reports the following result for supported obfuscation tools:
+
+| Check | Result code | Type | Severity | Detected tools |
+| --- | --- | --- | --- | --- |
+| code_obfuscation | `obfuscated_code_detected` | ERROR | 7 | Zend Guard, Source Guardian, ionCube |
+
+To see the result codes and severity values produced for a plugin, run:
+
+```bash
+wp plugin check <plugin> --format=csv --fields=code,type,severity,message
+```
+
+Use the check slug with `--checks` or `--exclude-checks`; use the result code with `--ignore-codes`. This distinction is important when filtering a check without suppressing a particular finding across other checks.
+
 ## Notes
 
 ### Escaping widget wrapper output


### PR DESCRIPTION
Closes #758

Adds a results-and-severity section to the checks documentation. It distinguishes check slugs from emitted result codes, documents ERROR/WARNING types and the 1–10 severity scale, includes the obfuscation example requested in the issue, and shows how to inspect codes with WP-CLI.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Ftools.php%3Fpage%3Dplugin-check%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fplugin-check%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1448-b5327e22cf384e229f39189c13670f1516881019.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->