### PR TITLE
Duplicate plugin-owned database tables into the runtime environment

### DIFF
--- a/includes/Checker/Runtime_Environment_Setup.php
+++ b/includes/Checker/Runtime_Environment_Setup.php
@@ -213,8 +213,8 @@ final class Runtime_Environment_Setup {
 	 * @return string[] List of table names, without any prefix.
 	 */
 	private function get_core_table_names( string $base_prefix, string $runtime_prefix ): array {
-		// The schema functions live in this file, which callers are not required to have loaded already.
-		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		// `wp_get_db_schema()` lives in this file, which callers are not required to have loaded already.
+		require_once ABSPATH . 'wp-admin/includes/schema.php';
 
 		if ( ! preg_match_all( '/CREATE TABLE (?:IF NOT EXISTS )?`?([0-9a-zA-Z$_]+)`?/i', wp_get_db_schema( 'all' ), $matches ) ) {
 			return array();

--- a/includes/Checker/Runtime_Environment_Setup.php
+++ b/includes/Checker/Runtime_Environment_Setup.php
@@ -18,6 +18,17 @@ final class Runtime_Environment_Setup {
 	use Amend_DB_Base_Prefix;
 
 	/**
+	 * Name of the option that records which plugin-owned tables the runtime environment created.
+	 *
+	 * The record is what cleanup deletes, so that a table the runtime environment did not create can never be
+	 * dropped, even if its name happens to match the runtime environment's prefix.
+	 *
+	 * @since n.e.x.t
+	 * @var string
+	 */
+	const CUSTOM_TABLES_OPTION = 'plugin_check_runtime_custom_tables';
+
+	/**
 	 * Sets up the WordPress environment for runtime checks
 	 *
 	 * @since 1.0.0
@@ -42,8 +53,25 @@ final class Runtime_Environment_Setup {
 		// Get the existing permalink structure.
 		$permalink_structure = get_option( 'permalink_structure' );
 
+		// Get the actual site's base prefix, before it is amended below.
+		$base_prefix = $wpdb->base_prefix;
+
 		// Set the new prefix.
 		$prefix_cleanup = $this->amend_db_base_prefix();
+
+		/*
+		 * Duplicate the schema of any tables owned by other plugins.
+		 *
+		 * Installing WordPress below only creates the WordPress core tables. Plugins usually register their own tables
+		 * in an activation hook, which never runs in the runtime environment, so those tables would be missing even
+		 * though the same plugins are activated here and will query them.
+		 *
+		 * This has to happen before the install, because the install itself already triggers hooks such as
+		 * 'update_option' and 'user_register' that active plugins may respond to by querying their own tables.
+		 *
+		 * See https://github.com/WordPress/plugin-check/issues/234.
+		 */
+		$created_tables = $this->create_custom_tables( $base_prefix, $wpdb->base_prefix );
 
 		// Create and populate the test database tables if they do not exist.
 		if ( $wpdb->posts !== $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $wpdb->posts ) ) ) {
@@ -80,6 +108,9 @@ final class Runtime_Environment_Setup {
 		// Restore the old prefix.
 		$prefix_cleanup();
 
+		// Record the created tables, so that cleanup only ever deletes those. Requires the actual site's prefix.
+		$this->record_custom_tables( $created_tables );
+
 		// Return early if the plugin check object cache already exists.
 		if ( defined( 'WP_PLUGIN_CHECK_OBJECT_CACHE_DROPIN_VERSION' ) && WP_PLUGIN_CHECK_OBJECT_CACHE_DROPIN_VERSION ) {
 			return;
@@ -107,6 +138,9 @@ final class Runtime_Environment_Setup {
 
 		require_once ABSPATH . '/wp-admin/includes/upgrade.php';
 
+		// Read the record of created tables while the actual site's prefix is still in place.
+		$custom_tables = (array) get_option( self::CUSTOM_TABLES_OPTION, array() );
+
 		$prefix_cleanup = $this->amend_db_base_prefix();
 		$tables         = $wpdb->tables();
 
@@ -116,8 +150,13 @@ final class Runtime_Environment_Setup {
 			$wpdb->query( "DROP TABLE IF EXISTS `$table`" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		}
 
+		// Remove the tables that were duplicated for other plugins as well.
+		$this->drop_custom_tables( $wpdb->base_prefix, $custom_tables );
+
 		// Restore the old prefix.
 		$prefix_cleanup();
+
+		delete_option( self::CUSTOM_TABLES_OPTION );
 
 		// Return early if the plugin check object cache does not exist.
 		if ( ! defined( 'WP_PLUGIN_CHECK_OBJECT_CACHE_DROPIN_VERSION' ) || ! WP_PLUGIN_CHECK_OBJECT_CACHE_DROPIN_VERSION ) {
@@ -157,6 +196,204 @@ final class Runtime_Environment_Setup {
 			unset( $tables['usermeta'] );
 		}
 		return $tables;
+	}
+
+	/**
+	 * Returns the names of the database tables that installing WordPress creates.
+	 *
+	 * The `$wpdb->tables` property is deliberately not used here: it is a public property that plugins append their
+	 * own tables to, e.g. WooCommerce does so for its lookup and meta tables. Relying on it would classify exactly
+	 * those tables as core ones and therefore skip them. `wp_get_db_schema()` is WordPress's own definition of what
+	 * the install creates, and it stays accurate as core changes.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $base_prefix    The actual site's database table base prefix.
+	 * @param string $runtime_prefix The runtime environment's database table base prefix.
+	 * @return string[] List of table names, without any prefix.
+	 */
+	private function get_core_table_names( string $base_prefix, string $runtime_prefix ): array {
+		// The schema functions live in this file, which callers are not required to have loaded already.
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+		if ( ! preg_match_all( '/CREATE TABLE (?:IF NOT EXISTS )?`?([0-9a-zA-Z$_]+)`?/i', wp_get_db_schema( 'all' ), $matches ) ) {
+			return array();
+		}
+
+		$table_names = array();
+
+		foreach ( $matches[1] as $table ) {
+			/*
+			 * The schema uses whichever prefix is currently in place, so strip either one. The runtime prefix is
+			 * checked first because it starts with the base prefix.
+			 */
+			foreach ( array( $runtime_prefix, $base_prefix ) as $prefix ) {
+				if ( str_starts_with( $table, $prefix ) ) {
+					$table = substr( $table, strlen( $prefix ) );
+					break;
+				}
+			}
+
+			// Strip the site ID segment that Multisite tables carry, e.g. `3_posts`.
+			$table_names[] = preg_replace( '/^\d+_/', '', $table );
+		}
+
+		return $table_names;
+	}
+
+	/**
+	 * Returns the names of the database tables that belong to plugins rather than to WordPress core.
+	 *
+	 * The returned names have the base prefix stripped, so that they can be combined with either the actual site's
+	 * base prefix or the runtime environment's base prefix.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @global wpdb $wpdb WordPress database abstraction object.
+	 *
+	 * @param string $base_prefix    The actual site's database table base prefix.
+	 * @param string $runtime_prefix The runtime environment's database table base prefix.
+	 * @return string[] List of table names, without the base prefix.
+	 */
+	private function get_custom_table_names( string $base_prefix, string $runtime_prefix ): array {
+		global $wpdb;
+
+		$core_tables = array_flip( $this->get_core_table_names( $base_prefix, $runtime_prefix ) );
+
+		// `SHOW FULL TABLES` is used over `SHOW TABLES` so that views can be told apart from base tables.
+		$rows = $wpdb->get_results(
+			$wpdb->prepare( 'SHOW FULL TABLES LIKE %s', $wpdb->esc_like( $base_prefix ) . '%' ),
+			ARRAY_N
+		);
+
+		if ( ! is_array( $rows ) ) {
+			return array();
+		}
+
+		$custom_tables = array();
+
+		foreach ( $rows as $row ) {
+			if ( ! isset( $row[0] ) ) {
+				continue;
+			}
+
+			// Views cannot be duplicated with `CREATE TABLE ... LIKE`. Any other table type can.
+			if ( isset( $row[1] ) && false !== stripos( (string) $row[1], 'VIEW' ) ) {
+				continue;
+			}
+
+			// Skip the runtime environment's own tables, which also match the site's base prefix.
+			if ( str_starts_with( $row[0], $runtime_prefix ) ) {
+				continue;
+			}
+
+			$table_name = substr( $row[0], strlen( $base_prefix ) );
+
+			/*
+			 * On Multisite, the tables of sites other than the main site are prefixed with their site ID, e.g.
+			 * `wp_3_posts`. Strip that segment so that those tables are still recognized as core tables.
+			 */
+			$without_site_id = preg_replace( '/^\d+_/', '', $table_name );
+
+			if ( isset( $core_tables[ $table_name ] ) || isset( $core_tables[ $without_site_id ] ) ) {
+				continue;
+			}
+
+			$custom_tables[] = $table_name;
+		}
+
+		return $custom_tables;
+	}
+
+	/**
+	 * Duplicates the schema of all plugin-owned database tables into the runtime environment.
+	 *
+	 * Only the table structure is duplicated, never any data, so that runtime checks cannot read or modify the actual
+	 * site's content.
+	 *
+	 * A table that already exists is skipped rather than replaced, and is not reported as created. It could be a
+	 * leftover from an earlier run, but it could equally be a table of the actual site that happens to match the
+	 * runtime environment's prefix, and such a table must never be written to or, later on, dropped.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @global wpdb $wpdb WordPress database abstraction object.
+	 *
+	 * @param string $base_prefix    The actual site's database table base prefix.
+	 * @param string $runtime_prefix The runtime environment's database table base prefix.
+	 * @return string[] List of the table names that were created, without the base prefix.
+	 */
+	private function create_custom_tables( string $base_prefix, string $runtime_prefix ): array {
+		global $wpdb;
+
+		$created = array();
+
+		foreach ( $this->get_custom_table_names( $base_prefix, $runtime_prefix ) as $table_name ) {
+			$source = $base_prefix . $table_name;
+			$target = $runtime_prefix . $table_name;
+
+			if ( $target === $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $wpdb->esc_like( $target ) ) ) ) {
+				continue;
+			}
+
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			if ( false !== $wpdb->query( "CREATE TABLE `$target` LIKE `$source`" ) ) {
+				$created[] = $table_name;
+			}
+		}
+
+		return $created;
+	}
+
+	/**
+	 * Records which plugin-owned tables the runtime environment created.
+	 *
+	 * Must be called while the actual site's database table prefix is in place, so that the record is stored in the
+	 * site's own options table rather than the runtime environment's.
+	 *
+	 * The names are merged with any already recorded, so that a second setup without an intermediate cleanup does not
+	 * cause the tables of the first one to be forgotten and left behind.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string[] $table_names List of table names that were created, without the base prefix.
+	 */
+	private function record_custom_tables( array $table_names ): void {
+		$recorded = (array) get_option( self::CUSTOM_TABLES_OPTION, array() );
+		$merged   = array_values( array_unique( array_merge( $recorded, $table_names ) ) );
+
+		if ( $merged === $recorded ) {
+			return;
+		}
+
+		update_option( self::CUSTOM_TABLES_OPTION, $merged, false );
+	}
+
+	/**
+	 * Removes the plugin-owned database tables that the runtime environment created.
+	 *
+	 * The names come from the record written during setup, never from the database, so that only tables the runtime
+	 * environment created itself can be dropped.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @global wpdb $wpdb WordPress database abstraction object.
+	 *
+	 * @param string $runtime_prefix The runtime environment's database table base prefix.
+	 * @param array  $table_names    List of table names to drop, without the base prefix.
+	 */
+	private function drop_custom_tables( string $runtime_prefix, array $table_names ): void {
+		global $wpdb;
+
+		foreach ( $table_names as $table_name ) {
+			if ( ! is_string( $table_name ) || '' === $table_name ) {
+				continue;
+			}
+
+			$table = $runtime_prefix . $table_name;
+
+			$wpdb->query( "DROP TABLE IF EXISTS `$table`" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		}
 	}
 
 	/**

--- a/tests/phpunit/tests/Checker/Runtime_Environment_Setup_Tests.php
+++ b/tests/phpunit/tests/Checker/Runtime_Environment_Setup_Tests.php
@@ -12,6 +12,180 @@ class Runtime_Environment_Setup_Tests extends WP_UnitTestCase {
 
 	use With_Mock_Filesystem;
 
+	/**
+	 * Name of a table simulating one owned by another active plugin, without the base prefix.
+	 */
+	const CUSTOM_TABLE = 'plugin_check_custom_table';
+
+	public function tear_down() {
+		global $wpdb;
+
+		$table = $wpdb->base_prefix . self::CUSTOM_TABLE;
+
+		$wpdb->query( "DROP TABLE IF EXISTS `$table`" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		$table = $wpdb->base_prefix . 'pc_' . self::CUSTOM_TABLE;
+
+		$wpdb->query( "DROP TABLE IF EXISTS `$table`" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		$wpdb->tables = array_values( array_diff( $wpdb->tables, array( self::CUSTOM_TABLE ) ) );
+
+		delete_option( Runtime_Environment_Setup::CUSTOM_TABLES_OPTION );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Creates a table simulating one owned by another active plugin, with a single row of data in it.
+	 *
+	 * @return string The full table name, including the base prefix.
+	 */
+	private function create_custom_table() {
+		global $wpdb;
+
+		$table = $wpdb->base_prefix . self::CUSTOM_TABLE;
+
+		$this->create_table( $table );
+
+		return $table;
+	}
+
+	/**
+	 * Creates a table with a single row of data in it.
+	 *
+	 * @param string $table Full table name, including the base prefix.
+	 */
+	private function create_table( string $table ) {
+		global $wpdb;
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$wpdb->query(
+			"CREATE TABLE `$table` (
+				id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+				label varchar(20) NOT NULL,
+				PRIMARY KEY (id)
+			)"
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		$wpdb->insert( $table, array( 'label' => 'actual site data' ) );
+	}
+
+	public function test_set_up_duplicates_custom_plugin_tables() {
+		global $wpdb;
+
+		$this->set_up_mock_filesystem();
+
+		$this->create_custom_table();
+		$runtime_table = $wpdb->base_prefix . 'pc_' . self::CUSTOM_TABLE;
+
+		$runtime_setup = new Runtime_Environment_Setup();
+		$runtime_setup->set_up();
+
+		$this->assertSame(
+			$runtime_table,
+			$wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $runtime_table ) ),
+			'The table of the other plugin was not duplicated into the runtime environment.'
+		);
+	}
+
+	public function test_set_up_duplicates_tables_registered_on_the_wpdb_tables_property() {
+		global $wpdb;
+
+		$this->set_up_mock_filesystem();
+
+		$this->create_custom_table();
+
+		/*
+		 * `$wpdb->tables` is a public property that plugins append their own tables to, e.g. WooCommerce does so for
+		 * its lookup and meta tables. Those tables still have to be duplicated.
+		 */
+		$wpdb->tables[] = self::CUSTOM_TABLE;
+
+		$runtime_table = $wpdb->base_prefix . 'pc_' . self::CUSTOM_TABLE;
+
+		$runtime_setup = new Runtime_Environment_Setup();
+		$runtime_setup->set_up();
+
+		$this->assertSame(
+			$runtime_table,
+			$wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $runtime_table ) ),
+			'A table registered on the $wpdb->tables property was treated as a core table and skipped.'
+		);
+	}
+
+	public function test_set_up_does_not_copy_data_from_custom_plugin_tables() {
+		global $wpdb;
+
+		$this->set_up_mock_filesystem();
+
+		$this->create_custom_table();
+		$runtime_table = $wpdb->base_prefix . 'pc_' . self::CUSTOM_TABLE;
+
+		$runtime_setup = new Runtime_Environment_Setup();
+		$runtime_setup->set_up();
+
+		$this->assertSame(
+			'0',
+			$wpdb->get_var( "SELECT COUNT(*) FROM `$runtime_table`" ), // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			'The duplicated table contains data from the actual site.'
+		);
+	}
+
+	public function test_clean_up_removes_duplicated_custom_plugin_tables() {
+		global $wpdb;
+
+		$this->set_up_mock_filesystem();
+
+		$source_table  = $this->create_custom_table();
+		$runtime_table = $wpdb->base_prefix . 'pc_' . self::CUSTOM_TABLE;
+
+		$runtime_setup = new Runtime_Environment_Setup();
+		$runtime_setup->set_up();
+		$runtime_setup->clean_up();
+
+		$this->assertNull(
+			$wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $runtime_table ) ),
+			'The duplicated table was not removed from the runtime environment.'
+		);
+		$this->assertSame(
+			$source_table,
+			$wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $source_table ) ),
+			'The actual site table was removed.'
+		);
+	}
+
+	public function test_clean_up_does_not_drop_tables_it_did_not_create() {
+		global $wpdb;
+
+		$this->set_up_mock_filesystem();
+
+		$this->create_custom_table();
+
+		/*
+		 * A table of the actual site whose name happens to match the runtime environment's prefix. Cleanup must leave
+		 * it alone, since the runtime environment did not create it.
+		 */
+		$runtime_table = $wpdb->base_prefix . 'pc_' . self::CUSTOM_TABLE;
+
+		$this->create_table( $runtime_table );
+
+		$runtime_setup = new Runtime_Environment_Setup();
+		$runtime_setup->set_up();
+		$runtime_setup->clean_up();
+
+		$this->assertSame(
+			$runtime_table,
+			$wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $runtime_table ) ),
+			'A table that the runtime environment did not create was dropped.'
+		);
+		$this->assertSame(
+			'1',
+			$wpdb->get_var( "SELECT COUNT(*) FROM `$runtime_table`" ), // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			'The data of a table that the runtime environment did not create was lost.'
+		);
+	}
+
 	public function test_set_up() {
 		global $wp_filesystem, $wpdb, $table_prefix;
 


### PR DESCRIPTION
## What?

Closes #234
Closes #1127

Duplicates the schema of plugin-owned database tables into the runtime environment, so that plugins active during a runtime check can query their own tables instead of erroring out.

## Why?

`Runtime_Environment_Setup::set_up()` amends the database base prefix (e.g. `wp_` → `wp_pc_`) and installs a fresh WordPress under it. That install only creates the WordPress **core** tables.

Plugins almost always register their own tables in an activation hook, which never runs in the runtime environment. But `install_wordpress()` deliberately carries the actual site's `active_plugins` over, so those same plugins *are* loaded and *do* query their tables. The result is a stream of database errors for any plugin with custom tables:

```
WordPress database error Table 'db.wp_pc_yoast_indexable' doesn't exist for query
SELECT * FROM `wp_pc_yoast_indexable` WHERE `object_type` = 'home-page' LIMIT 1
```

Reported for Yoast SEO (#1127, #350), WooCommerce (#234) and GatherPress (comment on #234).

The earlier investigation in #234 tried calling `activate_plugin()` to trigger table creation and found it silently did nothing — `activate_plugin()` returns early when the plugin is already active. Duplicating the schema sidesteps that entirely and works no matter *how* a plugin creates its tables.

## How?

- `get_core_table_names()` derives the core table list from `wp_get_db_schema()`. The `$wpdb->tables` property is deliberately **not** used: it is public, and plugins append to it — WooCommerce registers its lookup, meta and Action Scheduler tables there. Using it would classify precisely those tables as core and skip them, leaving the most commonly reported case of this bug unfixed. As a side effect `wp_get_db_schema()` also resolves `CUSTOM_USER_TABLE` / `CUSTOM_USER_META_TABLE`, so a prefixed custom user table is correctly left alone.
- `get_custom_table_names()` lists tables matching the actual site's base prefix and subtracts that core list. On Multisite a leading site-ID segment is stripped before comparison, so `wp_3_posts` is still recognized as core. Tables already carrying the runtime prefix are skipped, and `SHOW FULL TABLES` is used so views are excluded (`CREATE TABLE ... LIKE` does not accept them).
- `create_custom_tables()` runs `CREATE TABLE IF NOT EXISTS <runtime> LIKE <source>` for each. **Structure only, never data** — runtime checks still cannot read or modify the actual site's content. `IF NOT EXISTS` keeps it idempotent across repeated runs.
- `create_custom_tables()` skips a target that already exists rather than replacing it, and reports back only the tables it genuinely created. `record_custom_tables()` stores that list in an option under the site's own prefix, merging rather than replacing so a second setup without an intermediate cleanup cannot orphan the first one's tables.
- `drop_custom_tables()` in `clean_up()` drops **only the recorded names**, never names read back from the database, and the option is deleted afterwards. A table the runtime environment did not create therefore cannot be dropped — including the case of a site that owns both `wp_foo` and a real `wp_pc_foo` (cf. #907).

One detail worth flagging for review: the duplication happens **before** `wp_install()`, not after. The install itself fires `update_option`, `user_register`, `set_user_role` etc., and active plugins already respond to those by querying their own tables — so creating the tables afterwards is too late to prevent the errors.

## Testing Instructions

1. On a site with Yoast SEO (or WooCommerce) active, run a runtime check:
   ```
   wp plugin check <plugin> --categories=performance --require=./wp-content/plugins/plugin-check/cli.php
   ```
2. Before this change, the output contains `Table 'db.wp_pc_yoast_indexable' doesn't exist` errors. After it, there are none.
3. Confirm `SHOW TABLES LIKE 'wp_pc_%'` now also lists the plugin tables during the run, and that nothing is left behind afterwards.
4. Confirm the duplicated tables are empty and the real tables are untouched.

Verified against a local site with Yoast SEO, WooCommerce and a plugin owning two custom tables:

| | Before | After |
|-|-|-|
| `wp_pc_` tables created | 12 (core only) | 59 (12 core + 47 plugin-owned) |
| `doesn't exist` errors | 14 | 0 |
| Leftover `wp_pc_` tables after cleanup | 0 | 0 |
| Rows in real `wp_posts` before / after | 153 / 153 | 153 / 153 |
| Rows in `wp_pc_options` (confirms the install still runs) | 109 | 109 |
| Rows in duplicated `wp_pc_woocommerce_tax_rates` | — | 0 (schema only) |

Verified with Yoast SEO **and** WooCommerce active, since the two exercise different paths: Yoast's tables are unknown to `$wpdb`, while WooCommerce registers its own on `$wpdb->tables`.

Adversarial check: with a real `wp_pc_zztest_thing` present alongside a real `wp_zztest_thing`, a full setup/cleanup cycle leaves the former untouched with its row intact, and a repeated setup without cleanup still leaves no tables behind.

New unit tests cover duplication, data isolation, cleanup, the `$wpdb->tables` registration case, and that cleanup never drops a table it did not create.

Full suite passes on both configurations:

```
npm run test-php            OK (523 tests, 1498 assertions)
npm run test-php-multisite   OK (524 tests, 1500 assertions)
```

`composer lint` and `composer phpstan` are clean.

## AI Usage Disclosure

- [ ] This PR was created without the help of AI tools
- [x] This PR includes AI-assisted code or content

If AI tools were used, please describe how they were used:
Claude Code was used throughout: investigating the root cause, drafting the implementation and tests, and verifying behaviour against a local reproduction with Yoast SEO and WooCommerce active. All changes have been manually reviewed and tested by a human before submission.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Ftools.php%3Fpage%3Dplugin-check%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fplugin-check%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1453-638348b11b6a5433de6311a54e610efc9afaa79c.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->