### PR TITLE
Playground preview: derive PR number from the triggering run

### DIFF
--- a/.github/workflows/pr-playground-preview-publish.yml
+++ b/.github/workflows/pr-playground-preview-publish.yml
@@ -35,24 +35,46 @@ jobs:
             --name plugin-check-preview-metadata \
             --dir preview-metadata
 
-      - name: Read Playground preview metadata
+      - name: Resolve and verify Playground preview metadata
         id: metadata
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          # The build runs untrusted PR code, so its artifact is untrusted; the
+          # triggering run's head SHA is the only reliable value.
+          TRUSTED_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          pr_number="$(cat preview-metadata/pr-number)"
-          head_sha="$(cat preview-metadata/head-sha)"
+          artifact_pr_number="$(cat preview-metadata/pr-number)"
+          artifact_head_sha="$(cat preview-metadata/head-sha)"
 
-          if ! [[ "$pr_number" =~ ^[0-9]+$ ]]; then
-            echo "Invalid PR number in preview metadata: $pr_number" >&2
+          if ! [[ "$artifact_head_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Invalid head SHA in preview metadata: $artifact_head_sha" >&2
             exit 1
           fi
 
-          if ! [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "Invalid head SHA in preview metadata: $head_sha" >&2
+          if [[ "$artifact_head_sha" != "$TRUSTED_HEAD_SHA" ]]; then
+            echo "Refusing to publish: artifact head SHA ($artifact_head_sha) does not match the triggering run's head SHA ($TRUSTED_HEAD_SHA)." >&2
             exit 1
           fi
 
-          echo "pr-number=$pr_number" >> "$GITHUB_OUTPUT"
-          echo "head-sha=$head_sha" >> "$GITHUB_OUTPUT"
+          # Resolve the PR number from the trusted head SHA rather than the
+          # artifact-supplied value.
+          resolved_pr_number="$(
+            gh api "repos/${GH_REPO}/commits/${TRUSTED_HEAD_SHA}/pulls" \
+              --jq 'map(select(.state == "open")) | first | .number // empty'
+          )"
+
+          if ! [[ "$resolved_pr_number" =~ ^[0-9]+$ ]]; then
+            echo "Could not resolve an open pull request for head SHA $TRUSTED_HEAD_SHA." >&2
+            exit 1
+          fi
+
+          if [[ "$artifact_pr_number" != "$resolved_pr_number" ]]; then
+            echo "Notice: artifact PR number ($artifact_pr_number) does not match the PR resolved from the head SHA ($resolved_pr_number); using the resolved value." >&2
+          fi
+
+          echo "pr-number=$resolved_pr_number" >> "$GITHUB_OUTPUT"
+          echo "head-sha=$TRUSTED_HEAD_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Expose built artifact as a public URL
         id: expose

--- a/.github/workflows/pr-playground-preview-publish.yml
+++ b/.github/workflows/pr-playground-preview-publish.yml
@@ -58,10 +58,14 @@ jobs:
           fi
 
           # Resolve the PR number from the trusted head SHA rather than the
-          # artifact-supplied value.
+          # artifact-supplied value. The commits/{sha}/pulls association index
+          # omits fork PR heads, so list open PRs and match on the exact head
+          # SHA instead; this also prevents resolving a different PR that
+          # merely contains the commit.
           resolved_pr_number="$(
-            gh api "repos/${GH_REPO}/commits/${TRUSTED_HEAD_SHA}/pulls" \
-              --jq 'map(select(.state == "open")) | first | .number // empty'
+            gh api "repos/${GH_REPO}/pulls?state=open&per_page=100" --paginate \
+              --jq '.[] | select(.head.sha == env.TRUSTED_HEAD_SHA) | .number' \
+              | head -n 1
           )"
 
           if ! [[ "$resolved_pr_number" =~ ^[0-9]+$ ]]; then

--- a/.github/workflows/pr-playground-preview.yml
+++ b/.github/workflows/pr-playground-preview.yml
@@ -36,7 +36,8 @@ jobs:
           coverage: none
 
       - name: Install production Composer dependencies
-        run: composer install --no-dev --optimize-autoloader --no-interaction --no-progress
+        # --no-scripts stops a PR's composer.json from running code during the build.
+        run: composer install --no-dev --optimize-autoloader --no-interaction --no-progress --no-scripts
 
       - name: Build plugin zip honouring .distignore
         env:


### PR DESCRIPTION
## What

The `pr-playground-preview-publish.yml` workflow currently reads the PR number and head SHA back from the uploaded build artifact. This change instead:

- Takes the head SHA from the `workflow_run` event (`github.event.workflow_run.head_sha`) and requires the artifact's recorded SHA to match it.
- Resolves the pull request number from that head SHA through the API, rather than trusting the number embedded in the artifact.

The result is that the published preview always corresponds to the commit that was actually built and to the pull request that commit belongs to.

Additionally, `pr-playground-preview.yml` now passes `--no-scripts` to the preview build's `composer install`, so the zip is produced without executing package scripts.

## Why

Keeps the preview publish step aligned with the triggering run and makes the build step's output more predictable.

## Testing

- Workflow YAML validated; publish step fails closed if the SHA doesn't match or no open PR resolves for it.
- Worth a check on a fork-originated PR to confirm the PR number resolves as expected in the runner.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Ftools.php%3Fpage%3Dplugin-check%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fplugin-check%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1454-1fcf616d60b73c1bf6e295b66690347d3403b12d.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->