### PR TITLE
Avoid AI sanitization false positives for password, token, and API key fields

### DIFF
--- a/prompts/ai-review-sanitization.md
+++ b/prompts/ai-review-sanitization.md
@@ -13,3 +13,5 @@ Details:
 - If the data is passed directly to a function that handles its own sanitization (e.g., `update_option()` with a registered sanitize callback), it may not be an issue.
 - If the data is only used in a comparison (e.g., `if ( $_GET['action'] === 'delete' )`), the risk is lower but sanitization is still recommended.
 - Array access on superglobals should also be sanitized.
+- Passwords, tokens, secrets, signatures, and API keys are generally NOT eligible to be sanitized, as they can legitimately consist of any combination of characters. Sanitizing them can silently change their value (e.g., stripping characters), breaking authentication or comparisons. This is not an issue as long as the value is only stored (e.g., hashed with `wp_hash_password()`) or compared (e.g., with `wp_check_password()`, `hash_equals()`) and never displayed or used unsafely (e.g., in an unprepared SQL query or unescaped output).
+- Look at the array index key (e.g., `password`, `pwd`, `pass`, `token`, `secret`, `signature`, `api_key`, or similar) as well as how the value is used to determine whether it falls into this category.


### PR DESCRIPTION
## Summary

Fixes #1455

The `WordPress.Security.ValidatedSanitizedInput` sniff flags any access to superglobals (`$_POST`, `$_GET`, `$_REQUEST`, etc.) that isn't sanitized, including cases where the array key corresponds to a password, token, secret, signature, or API key.

However, sanitizing these kinds of values before comparing or storing them can silently change their actual value, since they can legitimately contain any combination of characters. This can break authentication or comparisons, and can also cause the AI false-positive analysis to miss a legitimate false positive.

## Changes

- Updated `prompts/ai-review-sanitization.md` (used by the AI-powered false-positive detection for `WordPress.Security.ValidatedSanitizedInput` issues) to instruct the AI reviewer that passwords, tokens, secrets, signatures, and API keys are generally not eligible to be sanitized, as long as they are only stored (e.g. hashed) or compared, and never displayed or used unsafely.
- This mirrors the criteria already applied by our internal review tool for this exact case.

## Why this approach

The `ValidatedSanitizedInput` sniff itself lives in the `wp-coding-standards/wpcs` vendor dependency, so it shouldn't be patched directly. Plugin Check already has a mechanism for handling this kind of contextual false positive: the AI-powered analysis (`AI_Analyzer.php`) that re-evaluates PHPCS findings using check-specific prompts. Updating the sanitization prompt is the least invasive way to apply this criterion, and only affects results when AI analysis (`--ai`) is enabled — the underlying PHPCS warning is unchanged for users who don't use AI review.

## Testing

- No behavior change for the static PHPCS check itself (existing `Plugin_Review_PHPCS_Check_Tests` unaffected).
- Prompts are plain text consumed by the AI model at runtime; there is no dedicated PHPUnit coverage for prompt content, consistent with the other prompt files in the `prompts/` directory.

---
**Disclaimer:** This PR description was drafted with the help of an AI (GitHub Copilot) based on a review of the codebase and the linked issue. The content has been reviewed by a human before publishing, but it is disclosed here for transparency.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Ftools.php%3Fpage%3Dplugin-check%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fplugin-check%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1456-7cff94860e14173cecef691eef316f54db393d6d.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->