### PR TITLE
Surface checks that failed to run

### DIFF
--- a/assets/js/plugin-check-admin.js
+++ b/assets/js/plugin-check-admin.js
@@ -756,6 +756,7 @@
 	) {
 		let isSuccessMessage = true;
 		let aiStats = null;
+		const failedChecks = [];
 		for ( let i = 0; i < checks.length; i++ ) {
 			try {
 				const results = await runCheck(
@@ -812,14 +813,15 @@
 					}
 				}
 			} catch {
-				// Ignore for now.
+				failedChecks.push( checks[ i ] );
 			}
 		}
 
 		renderFalsePositiveResults();
 		const resultsMessage = renderResultsMessage(
 			isSuccessMessage,
-			aiStats
+			aiStats,
+			failedChecks
 		);
 
 		// Announce the check results summary so screen-reader users know
@@ -831,15 +833,34 @@
 	}
 
 	/**
+	 * Substitutes printf-style placeholders in a translated string.
+	 * Handles both simple (%d, %s) and positional (%1$d, %2$s) placeholders.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param {string}    template The translated format string.
+	 * @param {...string} args     Replacement values.
+	 * @return {string} Formatted string with placeholders replaced.
+	 */
+	function sprintfReplace( template, ...args ) {
+		let i = 0;
+		return template.replace( /%(\d+\$)?[ds]/g, function ( _match, pos ) {
+			const index = pos ? parseInt( pos, 10 ) - 1 : i++;
+			return args[ index ] !== undefined ? args[ index ] : _match;
+		} );
+	}
+
+	/**
 	 * Renders result message.
 	 *
 	 * @since 1.0.0
 	 *
 	 * @param {boolean} isSuccessMessage Whether the message is a success message.
 	 * @param {Object}  aiStats          AI statistics.
+	 * @param {Array}   failedChecks     Slugs of checks whose request did not complete.
 	 * @return {string} The rendered results message.
 	 */
-	function renderResultsMessage( isSuccessMessage, aiStats ) {
+	function renderResultsMessage( isSuccessMessage, aiStats, failedChecks ) {
 		// Count errors and warnings to determine notice severity and compose the message.
 		const { errorCount, warningCount } = isSuccessMessage
 			? { errorCount: 0, warningCount: 0 }
@@ -860,27 +881,6 @@
 		if ( isSuccessMessage ) {
 			messageText = pluginCheck.successMessage;
 		} else {
-			/**
-			 * Substitutes printf-style placeholders in a translated string.
-			 * Handles both simple (%d, %s) and positional (%1$d, %2$s) placeholders.
-			 *
-			 * @param {string}    template The translated format string.
-			 * @param {...string} args     Replacement values.
-			 * @return {string} Formatted string with placeholders replaced.
-			 */
-			function sprintfReplace( template, ...args ) {
-				let i = 0;
-				return template.replace(
-					/%(\d+\$)?[ds]/g,
-					function ( _match, pos ) {
-						const index = pos ? parseInt( pos, 10 ) - 1 : i++;
-						return args[ index ] !== undefined
-							? args[ index ]
-							: _match;
-					}
-				);
-			}
-
 			// Build the individual count parts with proper plural/singular forms.
 			let errorPart = '';
 			if ( errorCount > 0 ) {
@@ -924,6 +924,20 @@
 				// Fallback to default message if somehow no errors/warnings.
 				messageText = pluginCheck.errorMessage;
 			}
+		}
+
+		// A check whose request did not complete has no results, so the counts above cannot speak for it.
+		if ( failedChecks && failedChecks.length ) {
+			messageType = 'error';
+
+			const failedText = sprintfReplace(
+				pluginCheck.failedChecksMessage,
+				failedChecks.join( ', ' )
+			);
+
+			messageText = isSuccessMessage
+				? failedText
+				: messageText + ' ' + failedText;
 		}
 
 		if ( aiStats ) {

--- a/assets/js/plugin-check-admin.js
+++ b/assets/js/plugin-check-admin.js
@@ -812,7 +812,8 @@
 						);
 					}
 				}
-			} catch {
+			} catch ( error ) {
+				console.error( error );
 				failedChecks.push( checks[ i ] );
 			}
 		}
@@ -836,10 +837,10 @@
 	 * Substitutes printf-style placeholders in a translated string.
 	 * Handles both simple (%d, %s) and positional (%1$d, %2$s) placeholders.
 	 *
-	 * @since 2.1.0
+	 * @since n.e.x.t
 	 *
-	 * @param {string}    template The translated format string.
-	 * @param {...string} args     Replacement values.
+	 * @param {string}             template The translated format string.
+	 * @param {...(string|number)} args     Replacement values.
 	 * @return {string} Formatted string with placeholders replaced.
 	 */
 	function sprintfReplace( template, ...args ) {
@@ -855,9 +856,9 @@
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param {boolean} isSuccessMessage Whether the message is a success message.
-	 * @param {Object}  aiStats          AI statistics.
-	 * @param {Array}   failedChecks     Slugs of checks whose request did not complete.
+	 * @param {boolean}  isSuccessMessage Whether the message is a success message.
+	 * @param {?Object}  aiStats          AI statistics.
+	 * @param {string[]} failedChecks     Slugs of checks whose request did not complete.
 	 * @return {string} The rendered results message.
 	 */
 	function renderResultsMessage( isSuccessMessage, aiStats, failedChecks ) {

--- a/includes/Admin/Admin_Page.php
+++ b/includes/Admin/Admin_Page.php
@@ -218,6 +218,8 @@ final class Admin_Page {
 					'summaryBothTemplate'             => __( '%1$s and %2$s found.', 'plugin-check' ),
 					/* translators: %s: Formatted issue count string (e.g. "3 errors" or "2 warnings"). */
 					'summarySingleTemplate'           => __( '%s found.', 'plugin-check' ),
+					/* translators: %s: Comma-separated list of check slugs. */
+					'failedChecksMessage'             => __( 'These checks could not be completed and their results are unknown: %s.', 'plugin-check' ),
 					'strings'                         => array(
 						'checkingPlugin' => __( 'Running plugin checks…', 'plugin-check' ),
 						'exportCsv'      => __( 'Export CSV', 'plugin-check' ),


### PR DESCRIPTION
A failed check request is no longer swallowed: the completion notice names the checks that did not run, instead of reporting "No errors found".

- [x] `/wp-admin/tools.php?page=plugin-check` — Performance category on an active plugin: notice lists the five runtime checks whose requests return 400
- [x] Same screen, Plugin Repo category: unchanged, reports the error/warning counts
- [x] `npm run lint-js`

Part of #1445.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Ftools.php%3Fpage%3Dplugin-check%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fplugin-check%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1457-745f4a85c998b0f9f92aaf95a0277a57d1f021e0.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->